### PR TITLE
feat: multi-device login sessions

### DIFF
--- a/Appy/Appy-frontend/src/app/app.component.ts
+++ b/Appy/Appy-frontend/src/app/app.component.ts
@@ -62,7 +62,7 @@ export class AppComponent implements OnInit {
   }
 
   public logOut(): void {
-    this.authService.logOut();
+    this.authService.logOut().subscribe(() => {});
   }
 
   public visibleNavigation(nav: Navigation): boolean {

--- a/Appy/Appy-frontend/src/app/shared/services/auth/auth.service.ts
+++ b/Appy/Appy-frontend/src/app/shared/services/auth/auth.service.ts
@@ -89,6 +89,32 @@ export class AuthService {
         });
     }
 
+    public logOut(): Observable<void> {
+        let refreshToken = this.refreshToken;
+
+        this.accessToken = null;
+        this.refreshToken = null;
+        localStorage.removeItem(this.ACCESS_TOKEN_KEY);
+        localStorage.removeItem(this.REFRESH_TOKEN_KEY);
+        this.facilityService.clear();
+        this.router.navigate(["login"]);
+
+        return new Observable<void>(s => {
+            if (refreshToken != null) {
+                this.httpClient.post<any>(appConfig.apiUrl + "user/logout", {
+                    refreshToken: refreshToken
+                }).subscribe({
+                    next: (o: any) => s.next(o),
+                    error: (o: any) => s.error(o)
+                });
+            }
+            else {
+                s.next();
+            }
+            
+        });
+    }
+
     private setTokens(accessToken: string, refreshToken: string, loadFacilities: boolean = true): Observable<void> | null {
         if (accessToken == null) {
             this.logOut();
@@ -115,15 +141,6 @@ export class AuthService {
 
     public isLoggedIn(): boolean {
         return this.accessToken != null;
-    }
-
-    public logOut(): void {
-        this.accessToken = null;
-        this.refreshToken = null;
-        localStorage.removeItem(this.ACCESS_TOKEN_KEY);
-        localStorage.removeItem(this.REFRESH_TOKEN_KEY);
-        this.facilityService.clear();
-        this.router.navigate(["login"]);
     }
 
     public getName(): { name: string, surname: string } | null {

--- a/Appy/Auth/JwtService.cs
+++ b/Appy/Auth/JwtService.cs
@@ -63,7 +63,6 @@ namespace Appy.Services
 
         public string GenerateToken(TimeSpan lifespan, params Claim[] claims)
         {
-            // generate token that is valid for 7 days
             var tokenHandler = new JwtSecurityTokenHandler();
             var key = Encoding.ASCII.GetBytes(jwtSecret);
             var tokenDescriptor = new SecurityTokenDescriptor

--- a/Appy/Controllers/UserController.cs
+++ b/Appy/Controllers/UserController.cs
@@ -46,5 +46,11 @@ namespace Appy.Controllers
 
             return Ok(response);
         }
+
+        [HttpPost("logout")]
+        public async Task LogOut([FromBody] RefreshTokenDTO dto)
+        {
+            await userService.LogOut(dto.RefreshToken);
+        }
     }
 }

--- a/Appy/Controllers/UserController.cs
+++ b/Appy/Controllers/UserController.cs
@@ -40,7 +40,7 @@ namespace Appy.Controllers
         }
 
         [HttpPost("refresh")]
-        public async Task<ActionResult> RefreshTokens([FromBody] RefreshTokensDTO dto)
+        public async Task<ActionResult> RefreshTokens([FromBody] RefreshTokenDTO dto)
         {
             var response = await userService.RefreshTokens(dto.RefreshToken);
 

--- a/Appy/Controllers/UserController.cs
+++ b/Appy/Controllers/UserController.cs
@@ -22,7 +22,7 @@ namespace Appy.Controllers
         {
             try
             {
-                var response = await userService.Authenticate(dto);
+                var response = await userService.Authenticate(dto, HttpContext.Request.Headers.UserAgent.ToString());
                 return Ok(response);
             }
             catch (HttpException)
@@ -34,7 +34,7 @@ namespace Appy.Controllers
         [HttpPost("register")]
         public async Task<ActionResult> Register(RegisterDTO dto)
         {
-            var response = await userService.Register(dto);
+            var response = await userService.Register(dto, HttpContext.Request.Headers.UserAgent.ToString());
 
             return Ok(response);
         }

--- a/Appy/DTOs/RefreshTokenDTO.cs
+++ b/Appy/DTOs/RefreshTokenDTO.cs
@@ -1,6 +1,6 @@
 ﻿namespace Appy.DTOs
 {
-    public class RefreshTokensDTO
+    public class RefreshTokenDTO
     {
         public string RefreshToken { get; set; }
     }

--- a/Appy/Domain/LoginSession.cs
+++ b/Appy/Domain/LoginSession.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Appy.Domain
+{
+    [Index(nameof(Family), IsUnique = true)]
+    public class LoginSession
+    {
+        public int Id { get; set; }
+
+        public string UserAgent { get; set; }
+
+        public string Family { get; set; }
+        public string RefreshToken { get; set; }
+
+        public int UserId { get; set; }
+        public User User { get; set; }
+    }
+}

--- a/Appy/Domain/MainDbContext.cs
+++ b/Appy/Domain/MainDbContext.cs
@@ -6,6 +6,7 @@ namespace Appy.Domain
     public class MainDbContext : DbContext
     {
         public DbSet<User> Users { get; set; }
+        public DbSet<LoginSession> LoginSessions { get; set; }
         public DbSet<Facility> Facilities { get; set; }
         public DbSet<Service> Services { get; set; }
         public DbSet<Appointment> Appointments { get; set; }

--- a/Appy/Domain/User.cs
+++ b/Appy/Domain/User.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Appy.Domain
+﻿namespace Appy.Domain
 {
     public class User
     {
@@ -13,11 +11,10 @@ namespace Appy.Domain
         public byte[] Salt { get; set; }
 
         public int? SelectedFacilityId { get; set; }
-        public string? RefreshToken { get; set; }
 
+        public ICollection<LoginSession> LoginSessions { get; set; }
         public ICollection<Facility> Facilities { get; set; }
 
-        //Metode
         public List<string> GetRoles()
         {
             var roles = new List<string>();

--- a/Appy/Migrations/20240802155856_AddMultipleLoginSessions.Designer.cs
+++ b/Appy/Migrations/20240802155856_AddMultipleLoginSessions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Appy.Domain;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Appy.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240802155856_AddMultipleLoginSessions")]
+    partial class AddMultipleLoginSessions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Appy/Migrations/20240802155856_AddMultipleLoginSessions.cs
+++ b/Appy/Migrations/20240802155856_AddMultipleLoginSessions.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Appy.Migrations
+{
+    public partial class AddMultipleLoginSessions : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RefreshToken",
+                table: "Users");
+
+            migrationBuilder.CreateTable(
+                name: "LoginSessions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserAgent = table.Column<string>(type: "text", nullable: false),
+                    Family = table.Column<string>(type: "text", nullable: false),
+                    RefreshToken = table.Column<string>(type: "text", nullable: false),
+                    UserId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LoginSessions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_LoginSessions_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LoginSessions_Family",
+                table: "LoginSessions",
+                column: "Family",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LoginSessions_UserId",
+                table: "LoginSessions",
+                column: "UserId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LoginSessions");
+
+            migrationBuilder.AddColumn<string>(
+                name: "RefreshToken",
+                table: "Users",
+                type: "text",
+                nullable: true);
+        }
+    }
+}

--- a/Appy/Services/UserService.cs
+++ b/Appy/Services/UserService.cs
@@ -230,7 +230,7 @@ namespace Appy.Services
         private string GenerateAccessJwtToken(User user)
         {
             return jwtService.GenerateToken(
-                new TimeSpan(hours: 0, minutes: 0, seconds: 10),
+                new TimeSpan(hours: 1, minutes: 0, seconds: 10),
                 new Claim("id", user.Id.ToString()),
                 new Claim("name", user.Name),
                 new Claim("surname", user.Surname),

--- a/Appy/Services/UserService.cs
+++ b/Appy/Services/UserService.cs
@@ -11,8 +11,8 @@ namespace Appy.Services
 {
     public interface IUserService
     {
-        Task<LogInResponseDTO> Authenticate(LogInDTO model);
-        Task<LogInResponseDTO> Register(RegisterDTO model);
+        Task<LogInResponseDTO> Authenticate(LogInDTO model, string userAgent);
+        Task<LogInResponseDTO> Register(RegisterDTO model, string userAgent);
         Task<LogInResponseDTO> RefreshTokens(string refreshToken);
         Task<User> GetById(int id);
     }
@@ -28,7 +28,7 @@ namespace Appy.Services
             this.jwtService = jwtService;
         }
 
-        public async Task<LogInResponseDTO> Authenticate(LogInDTO model)
+        public async Task<LogInResponseDTO> Authenticate(LogInDTO model, string userAgent)
         {
             var user = await context.Users.FirstOrDefaultAsync(x => x.Email == model.Email);
             if (user == null)
@@ -40,9 +40,16 @@ namespace Appy.Services
                 throw new BadRequestException();
 
             var accessToken = GenerateAccessJwtToken(user);
-            var refreshToken = GenerateRefreshJwtToken(user.Id, GenerateFamily());
+            var refreshTokenFamily = GenerateFamily();
+            var refreshToken = GenerateRefreshJwtToken(user.Id, refreshTokenFamily);
 
-            user.RefreshToken = refreshToken;
+            context.LoginSessions.Add(new LoginSession()
+            {
+                UserAgent = userAgent,
+                RefreshToken = refreshToken,
+                Family = refreshTokenFamily,
+                User = user,
+            });
             await context.SaveChangesAsync();
 
             return new LogInResponseDTO()
@@ -52,7 +59,7 @@ namespace Appy.Services
             };
         }
 
-        public async Task<LogInResponseDTO> Register(RegisterDTO model)
+        public async Task<LogInResponseDTO> Register(RegisterDTO model, string userAgent)
         {
             var userWithSameEmail = await context.Users.SingleOrDefaultAsync(x => x.Email == model.Email);
             if (userWithSameEmail != null)
@@ -74,9 +81,16 @@ namespace Appy.Services
             await context.SaveChangesAsync();
 
             var accessToken = GenerateAccessJwtToken(user);
-            var refreshToken = GenerateRefreshJwtToken(user.Id, GenerateFamily());
+            var refreshTokenFamily = GenerateFamily();
+            var refreshToken = GenerateRefreshJwtToken(user.Id, refreshTokenFamily);
 
-            user.RefreshToken = refreshToken;
+            context.LoginSessions.Add(new LoginSession()
+            {
+                UserAgent = userAgent,
+                RefreshToken = refreshToken,
+                Family = refreshTokenFamily,
+                User = user,
+            });
             await context.SaveChangesAsync();
 
             return new LogInResponseDTO()
@@ -86,36 +100,44 @@ namespace Appy.Services
             };
         }
 
-        // Refresh token rotation -> every time refresh token is used, generate a new one
-        // Reuse protection -> using old but valid refresh token invalidates whole family
+        // 1. Refresh token rotation -> every time refresh token is used, a new refresh token is generated
+        // 2. Reuse protection -> refresh tokens generated on access token refresh use the same family
+        //                        so if a refresh token is used which is valid and has the same family but is old
+        //                        the whole refresh token family must be invalidated
         public async Task<LogInResponseDTO> RefreshTokens(string refreshToken)
         {
             // get userId claim
-            var (valid, token) = await jwtService.ValidateToken(refreshToken, validateLifetime: false);
-            if (!valid || token == null)
+            var (valid, parsedRefreshToken) = await jwtService.ValidateToken(refreshToken, validateLifetime: false);
+            if (!valid || parsedRefreshToken == null)
                 throw new BadRequestException();
 
-            if (!int.TryParse(token.Claims.FirstOrDefault(c => c.Type == "id")?.Value, out int userId))
+            string receivedFamily = parsedRefreshToken.Claims.FirstOrDefault(c => c.Type == "family")?.Value
+                ?? throw new BadRequestException();
+
+            if (!int.TryParse(parsedRefreshToken.Claims.FirstOrDefault(c => c.Type == "id")?.Value, out int userId))
                 throw new BadRequestException();
 
-            var user = await context.Users.FirstOrDefaultAsync(x => x.Id == userId);
-            if (user == null)
+            var user = await context.Users.Include(u => u.LoginSessions.Where(s => s.Family == receivedFamily)).FirstOrDefaultAsync(x => x.Id == userId) 
+                ?? throw new BadRequestException();
+
+            // there is no active login session for this user for this family, so this refresh token is old
+            if (user.LoginSessions.Count == 0)
                 throw new BadRequestException();
 
-            string? currentFamily = user.RefreshToken == null ? null : jwtService.ParseToken(user.RefreshToken)?.Claims.FirstOrDefault(c => c.Type == "family")?.Value;
+            var loginSession = user.LoginSessions.Single();
 
-            // check families
-            {
-                string? receivedFamily = token.Claims.FirstOrDefault(c => c.Type == "family")?.Value;
-                if (receivedFamily == null)
-                    throw new BadRequestException();
+            string currentFamily = jwtService.ParseToken(loginSession.RefreshToken)?.Claims.FirstOrDefault(c => c.Type == "family")?.Value 
+                ?? throw new Exception("Failed to get current family from the current saved refresh token");
 
-                if (user.RefreshToken != refreshToken)
+            { // check families
+                if (loginSession.RefreshToken != refreshToken)
                 {
-                    // if we received a valid token with the same family someone stole the refresh token!
+                    // we received valid but old refresh token with the same family, so it means it was reused
+                    // so someone stole the refresh token!
                     if (currentFamily == receivedFamily)
                     {
-                        user.RefreshToken = null;
+                        // invalidate the whole family
+                        user.LoginSessions.Remove(loginSession);
                         await context.SaveChangesAsync();
                     }
 
@@ -123,21 +145,21 @@ namespace Appy.Services
                 }
             }
 
-            // check lifetime
-            {
+            { // check lifetime
                 var (validLifetime, tokenLifetime) = await jwtService.ValidateToken(refreshToken, validateLifetime: true);
                 if (!validLifetime || tokenLifetime == null)
-                    throw new BadRequestException();
-            }
+                {
+                    user.LoginSessions.Remove(loginSession);
+                    await context.SaveChangesAsync();
 
-            // generate new
-            if (currentFamily == null)
-                currentFamily = GenerateFamily();
+                    throw new BadRequestException();
+                }
+            }
 
             var newRefreshToken = GenerateRefreshJwtToken(userId, currentFamily);
             var newAccesToken = GenerateAccessJwtToken(user);
 
-            user.RefreshToken = newRefreshToken;
+            loginSession.RefreshToken = newRefreshToken;
             await context.SaveChangesAsync();
 
             return new LogInResponseDTO()
@@ -177,7 +199,7 @@ namespace Appy.Services
             return hashed;
         }
 
-        private string GenerateFamily()
+        private static string GenerateFamily()
         {
             return Encoding.ASCII.GetString(RandomNumberGenerator.GetBytes(64));
         }
@@ -185,7 +207,7 @@ namespace Appy.Services
         private string GenerateAccessJwtToken(User user)
         {
             return jwtService.GenerateToken(
-                new TimeSpan(hours: 3, minutes: 0, seconds: 0),
+                new TimeSpan(hours: 0, minutes: 0, seconds: 10),
                 new Claim("id", user.Id.ToString()),
                 new Claim("name", user.Name),
                 new Claim("surname", user.Surname),


### PR DESCRIPTION
Up until now, it was possible to have only one login session per user. Logging in from another device would generate a new refresh token which would be saved over the last one, so when the original refresh token is used, the user gets logged out.

With this PR, for each new log in a session is created with it's own refresh token. On tokens refresh, correct session is found using the refresh token family.

I also had to implement log out on the backend because else the log in session would never be cleared.