### PR TITLE
fix: refresh token family generation

### DIFF
--- a/Appy/Services/UserService.cs
+++ b/Appy/Services/UserService.cs
@@ -224,7 +224,10 @@ namespace Appy.Services
 
         private static string GenerateFamily()
         {
-            return Encoding.ASCII.GetString(RandomNumberGenerator.GetBytes(64));
+            var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+            var familyLen = 64;
+
+            return new string(Enumerable.Range(0, familyLen).Select(_ => chars[RandomNumberGenerator.GetInt32(chars.Length)]).ToArray());
         }
 
         private string GenerateAccessJwtToken(User user)


### PR DESCRIPTION
SQL database isn't happy with ascii char 0, so I made it to use only letters and numbers.