### PR TITLE
fix: log exceptions in JwtService and InstagramMessagingService (#73)

### DIFF
--- a/Appy/Auth/JwtService.cs
+++ b/Appy/Auth/JwtService.cs
@@ -15,10 +15,12 @@ namespace Appy.Services
     public class JwtService : IJwtService
     {
         private string jwtSecret;
+        private readonly ILogger<JwtService> logger;
 
-        public JwtService(IConfiguration configuration)
+        public JwtService(IConfiguration configuration, ILogger<JwtService> logger)
         {
             this.jwtSecret = configuration["JwtSecret"]!;
+            this.logger = logger;
         }
 
         public async Task<(bool valid, JwtSecurityToken? token)> ValidateToken(string token, bool validateLifetime = true)
@@ -38,12 +40,22 @@ namespace Appy.Services
                 });
 
                 if (!result.IsValid)
+                {
+                    if (result.Exception != null)
+                        logger.LogDebug(result.Exception, "JWT validation failed");
                     return (false, null);
+                }
 
                 return (true, result.SecurityToken as JwtSecurityToken);
             }
-            catch
+            catch (SecurityTokenException e)
             {
+                logger.LogDebug(e, "JWT validation rejected token");
+                return (false, null);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Unexpected exception while validating JWT");
                 return (false, null);
             }
         }
@@ -55,8 +67,14 @@ namespace Appy.Services
                 var tokenHandler = new JwtSecurityTokenHandler();
                 return tokenHandler.ReadJwtToken(token);
             }
-            catch (Exception)
+            catch (ArgumentException e)
             {
+                logger.LogDebug(e, "Failed to parse JWT: malformed input");
+                return null;
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Unexpected exception while parsing JWT");
                 return null;
             }
         }

--- a/Appy/Services/MessagingServices/InstagramMessagingService.cs
+++ b/Appy/Services/MessagingServices/InstagramMessagingService.cs
@@ -91,7 +91,7 @@ namespace Appy.Services.MessagingServices
             }
             catch (Exception e)
             {
-                logger.LogError("Exception while trying to HTTP GET from Instagram API on {0}, message: {1}", url, e.Message);
+                logger.LogError(e, "Exception while trying to HTTP GET from Instagram API on {0}", url);
 
                 return null;
             }
@@ -122,7 +122,7 @@ namespace Appy.Services.MessagingServices
             }
             catch (Exception e)
             {
-                logger.LogError("Exception while trying to HTTP POST to Instagram API on {0}, message: {1}", url, e.Message);
+                logger.LogError(e, "Exception while trying to HTTP POST to Instagram API on {0}", url);
 
                 return null;
             }


### PR DESCRIPTION
Closes #73

## Summary
- `JwtService` previously had bare `catch` blocks with no logging. Misconfiguration (missing/bad `JwtSecret`, encoding errors) was indistinguishable from clients sending expired/invalid tokens. Now: expected validation failures and `SecurityTokenException` log at **Debug**; unexpected exceptions log at **Error** with full stack trace.
- `InstagramMessagingService` already logged but only passed `e.Message`. Now passes the exception object so the structured logger captures the full stack trace.
- Return values unchanged — callers see identical behavior.

## Test plan
- [x] `dotnet build` clean (0 errors)
- [x] `dotnet test` — all 19 unit tests pass
- [ ] Cypress E2E pass on PR CI