### PR TITLE
fix: restrict dev CORS to localhost frontend and drop AllowCredentials (#72)

### DIFF
--- a/Appy/Program.cs
+++ b/Appy/Program.cs
@@ -82,8 +82,7 @@ if (app.Environment.IsDevelopment())
     app.UseCors(x => x
         .AllowAnyMethod()
         .AllowAnyHeader()
-        .SetIsOriginAllowed(origin => true) // allow any origin
-        .AllowCredentials()); // allow credentials
+        .WithOrigins("http://localhost:4200"));
 }
 
 app.UseMiddleware<ExceptionMiddleware>();


### PR DESCRIPTION
## Summary
- Replace `SetIsOriginAllowed(origin => true)` with an explicit `WithOrigins("http://localhost:4200")` allowlist in the dev-only CORS policy
- Drop `AllowCredentials()` — auth is Bearer-token via the `Authorization` header, nothing in the app uses cookie credentials

Closes #72.

## Context
The issue flagged a wildcard origin + `AllowCredentials()` as a CSRF risk. The actual blast radius is smaller than the issue suggested — the CORS block is wrapped in `if (app.Environment.IsDevelopment())` (so production has no permissive CORS) and auth is Bearer-token, not cookie-based, so a malicious cross-origin site cannot make the browser auto-attach credentials. Still worth tightening as defense-in-depth and removes the footgun if cookie auth is ever introduced later.

## Test plan
- [x] `dotnet build` succeeds
- [ ] `npx ng serve` (localhost:4200) can still call the dev backend at `https://localhost:5001`
- [ ] Cypress E2E run is green