### PR TITLE
fix: use IHttpClientFactory for InstagramMessagingService (#74)

### DIFF
--- a/Appy/Program.cs
+++ b/Appy/Program.cs
@@ -20,7 +20,10 @@ builder.Services.AddDbContext<MainDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("Main")));
 builder.Services.AddSingleton<IJwtService, JwtService>();
 
-builder.Services.AddSingleton<InstagramMessagingService>();
+builder.Services.AddHttpClient<InstagramMessagingService>(client =>
+{
+    client.BaseAddress = new Uri("https://graph.instagram.com/v21.0");
+});
 builder.Services.AddScoped<IMessagingServiceManager, MessagingServiceManager>();
 
 builder.Services.AddScoped<IUserService, UserService>();

--- a/Appy/Services/MessagingServices/InstagramMessagingService.cs
+++ b/Appy/Services/MessagingServices/InstagramMessagingService.cs
@@ -4,15 +4,12 @@ namespace Appy.Services.MessagingServices
 {
     public class InstagramMessagingService : IMessagingService
     {
-        private static HttpClient httpClient = new HttpClient()
-        {
-            BaseAddress = new Uri("https://graph.instagram.com/v21.0"),
-        };
-
+        private readonly HttpClient httpClient;
         private readonly ILogger<InstagramMessagingService> logger;
 
-        public InstagramMessagingService(ILogger<InstagramMessagingService> logger)
+        public InstagramMessagingService(HttpClient httpClient, ILogger<InstagramMessagingService> logger)
         {
+            this.httpClient = httpClient;
             this.logger = logger;
         }
 


### PR DESCRIPTION
Closes #74.

## Summary
- Replace the static `HttpClient` field in `InstagramMessagingService` with one injected via constructor.
- Register the service as a typed client through `AddHttpClient<InstagramMessagingService>` in `Program.cs` (`BaseAddress` preserved).
- Lifetime changes Singleton → Transient (default for typed clients). Safe: the service is stateless, and its only consumer `MessagingServiceManager` is Scoped.

## Why
A long-lived static `HttpClient` pins its `HttpMessageHandler` forever, so DNS changes never propagate. `IHttpClientFactory` recycles handlers (default 2 min), which fixes the DNS-staleness issue and also opens the door to per-environment Polly/retry/cert config later.

(Note: the issue title mentions "socket exhaustion" — that's actually the *opposite* anti-pattern, `new HttpClient()` per request. The fix here is still the right move; the rationale is just DNS refresh + lifecycle management.)

## Test plan
- [x] `dotnet build` — clean, no new warnings
- [x] `dotnet test` — 19/19 unit tests pass
- [x] Cypress E2E — 30/30 pass (appointments spec)
- [ ] Smoke-check Instagram message send in an env with a real token (out of scope here — no token in dev)