### PR TITLE
ci: require unit tests (and e2e) to merge (#120)

### DIFF
--- a/.github/workflows/backend_unit_tests_on_pr.yml
+++ b/.github/workflows/backend_unit_tests_on_pr.yml
@@ -1,4 +1,4 @@
-name: Unit Tests
+name: Backend Unit Tests
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  unit-tests:
+  backend-unit-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,5 +28,5 @@ jobs:
       - name: Restore test project
         run: dotnet restore ./Appy.Tests/Appy.Tests.csproj
 
-      - name: Run unit tests
+      - name: Run backend unit tests
         run: dotnet test ./Appy.Tests/Appy.Tests.csproj --no-restore --verbosity normal

--- a/.github/workflows/frontend_unit_tests_on_pr.yml
+++ b/.github/workflows/frontend_unit_tests_on_pr.yml
@@ -1,0 +1,35 @@
+name: Frontend Unit Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  frontend-unit-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./Appy/Appy-frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Cache Node.js modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
+      - name: Install frontend dependencies
+        run: npm install
+
+      - name: Run frontend unit tests
+        run: npx ng test --no-watch --no-progress --browsers=ChromeHeadlessCI

--- a/.github/workflows/unit_tests_on_pr.yml
+++ b/.github/workflows/unit_tests_on_pr.yml
@@ -1,0 +1,32 @@
+name: Unit Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore test project
+        run: dotnet restore ./Appy.Tests/Appy.Tests.csproj
+
+      - name: Run unit tests
+        run: dotnet test ./Appy.Tests/Appy.Tests.csproj --no-restore --verbosity normal

--- a/Appy/Appy-frontend/CLAUDE.md
+++ b/Appy/Appy-frontend/CLAUDE.md
@@ -8,6 +8,7 @@ Angular 16 SPA. All API calls include `Authorization: Bearer <token>` and `facil
 npm install          # Install dependencies
 npx ng serve         # Dev server → http://localhost:4200
 npx ng build         # Production build into dist/
+npx ng test          # Unit tests (Karma/Jasmine, watch mode)
 npx cypress open     # Interactive E2E runner
 npx cypress run      # Headless E2E (used in CI)
 ```

--- a/Appy/Appy-frontend/karma.conf.js
+++ b/Appy/Appy-frontend/karma.conf.js
@@ -38,6 +38,14 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: ['Chrome'],
+    // Headless launcher for CI; --no-sandbox is required on GitHub-hosted runners.
+    // Select it with `ng test --no-watch --browsers=ChromeHeadlessCI`.
+    customLaunchers: {
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu']
+      }
+    },
     singleRun: false,
     restartOnFileChange: true
   });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,8 @@ npx cypress run      # Headless E2E
 
 ## CI/CD
 
-- **PRs to `main`**: two required status checks must pass before merging —
+- **PRs to `main`**: three required status checks must pass before merging —
   - `e2e` — E2E tests via `.github/workflows/e2e_on_pr.yml` (real Postgres, live backend + frontend + Cypress)
-  - `unit-tests` — backend xUnit tests via `.github/workflows/unit_tests_on_pr.yml` (`dotnet test`, fully mocked — no Postgres/frontend)
+  - `backend-unit-tests` — backend xUnit tests via `.github/workflows/backend_unit_tests_on_pr.yml` (`dotnet test`, fully mocked — no Postgres/frontend)
+  - `frontend-unit-tests` — frontend Karma/Jasmine tests via `.github/workflows/frontend_unit_tests_on_pr.yml` (`ng test` headless via the `ChromeHeadlessCI` launcher)
 - **GitHub releases**: Docker image built for `linux/amd64` + `linux/arm64`, pushed to `worly/appy:latest`, then a Watchtower webhook triggers auto-deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,5 +92,7 @@ npx cypress run      # Headless E2E
 
 ## CI/CD
 
-- **PRs to `main`**: E2E tests via `.github/workflows/e2e_on_pr.yml` (real Postgres, live backend + frontend + Cypress)
+- **PRs to `main`**: two required status checks must pass before merging —
+  - `e2e` — E2E tests via `.github/workflows/e2e_on_pr.yml` (real Postgres, live backend + frontend + Cypress)
+  - `unit-tests` — backend xUnit tests via `.github/workflows/unit_tests_on_pr.yml` (`dotnet test`, fully mocked — no Postgres/frontend)
 - **GitHub releases**: Docker image built for `linux/amd64` + `linux/arm64`, pushed to `worly/appy:latest`, then a Watchtower webhook triggers auto-deploy


### PR DESCRIPTION
@
Closes #120.

## What

Adds backend **and** frontend unit-test CI workflows and makes them plus e2e **required status checks** for merging into `main`.

### Background
The issue asked to run unit tests on merge "together with the existing e2e tests." While implementing, I found that **e2e was not actually a merge gate** — branch protection on `main` had no required status checks (`contexts: []`) and no rulesets. The e2e workflow ran on PRs but did not block merging. This PR closes that gap too.

### Changes
- **`.github/workflows/backend_unit_tests_on_pr.yml`** — runs `dotnet test` on the `Appy.Tests` xUnit project (fully mocked — no Postgres/frontend). Job/check: `backend-unit-tests`.
- **`.github/workflows/frontend_unit_tests_on_pr.yml`** — runs `ng test` headless (Karma/Jasmine). Job/check: `frontend-unit-tests`.
- **`karma.conf.js`** — adds a `ChromeHeadlessCI` custom launcher (`--no-sandbox`) for CI; does not affect local `ng test`.
- **`CLAUDE.md` / `Appy-frontend/CLAUDE.md`** — document the three required checks and the `ng test` command.

Both run on PRs to `main` and via `workflow_dispatch`.

### Branch protection (applied separately via API)
`main` will require all three checks before merge, preserving existing rules (`strict: true`, code-owner reviews, conversation resolution):

```
required_status_checks.checks = [
  { context: "e2e" },
  { context: "backend-unit-tests" },
  { context: "frontend-unit-tests" },
]
```

> Note: enabling required checks affects open PRs created before these workflows existed — they will show "Expected" until rebased. `enforce_admins` is `false`, so the owner can still merge those.

## Verification
- Backend: 47/47 xUnit tests pass (locally + in CI on the first commit).
- Frontend: 128/128 Karma tests pass locally headless via `ChromeHeadlessCI`.
- All three checks run on this PR.
@