### PR TITLE
Remove NO_FRONTEND env var; consolidate frontend build & serving

### DIFF
--- a/.github/workflows/e2e_on_pr.yml
+++ b/.github/workflows/e2e_on_pr.yml
@@ -28,8 +28,7 @@ jobs:
       ASPNETCORE_ENVIRONMENT: Development
       JwtSecret: "ci-throwaway-secret-not-used-in-production"
       ConnectionStrings__Main: "Server=localhost;Port=5432;Database=Appy;Userid=postgres;Password=password"
-      NO_FRONTEND: true
-          
+
     steps:
       - uses: actions/checkout@v3
 

--- a/Appy/.dockerignore
+++ b/Appy/.dockerignore
@@ -1,3 +1,6 @@
 Dockerfile
 bin/
 obj/
+Appy-frontend/node_modules/
+Appy-frontend/build/
+Appy-frontend/.angular/

--- a/Appy/Appy-frontend/cypress/CLAUDE.md
+++ b/Appy/Appy-frontend/cypress/CLAUDE.md
@@ -6,7 +6,7 @@ Cypress end-to-end tests that run against the full live stack. Triggered automat
 
 The workflow:
 1. Starts Postgres 14
-2. Builds and starts the backend (`ASPNETCORE_ENVIRONMENT=Development`, `NO_FRONTEND=true`)
+2. Builds and starts the backend (`ASPNETCORE_ENVIRONMENT=Development` — in Development the backend does not serve the frontend)
 3. Starts `npx ng serve` for the frontend
 4. Runs Cypress against `http://localhost:4200`
 

--- a/Appy/Appy.csproj
+++ b/Appy/Appy.csproj
@@ -34,30 +34,4 @@
     <None Include="$(SpaRoot)**" Exclude="$(SpaRoot)node_modules\**" />
   </ItemGroup>
 
-  <Target Name="DebugEnsureNodeEnv" BeforeTargets="Build" Condition="'$(Configuration)' == 'Debug' And !Exists('$(SpaRoot)node_modules') And '$(NO_FRONTEND)' != 'true'">
-    <!-- Ensure Node.js is installed -->
-    <Exec Command="node --version" ContinueOnError="true">
-      <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
-    </Exec>
-    <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
-    <Message Importance="high" Text="Restoring dependencies using 'npm'. This may take several minutes..." />
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
-  </Target>
-
-  <Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
-    <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm run build" />
-
-    <!-- Include the newly-built files in the publish output -->
-    <ItemGroup>
-      <DistFiles Include="$(SpaRoot)build\**" />
-      <ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
-        <RelativePath>%(DistFiles.Identity)</RelativePath>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      </ResolvedFileToPublish>
-    </ItemGroup>
-  </Target>
-
 </Project>

--- a/Appy/CLAUDE.md
+++ b/Appy/CLAUDE.md
@@ -39,7 +39,6 @@ All application services are registered as **Scoped**. The one exception is `Cro
 
 - **Development**: `appsettings.json`
 - **Production**: environment variables (UPPER_SNAKE_CASE — see `Utils/CLAUDE.md`)
-- `NO_FRONTEND=true` env var skips static file serving (used in CI)
 
 ## Database
 
@@ -49,6 +48,9 @@ PostgreSQL via `Npgsql.EntityFrameworkCore.PostgreSQL`. Single `AppDbContext`. M
 
 `GET /health` returns 200 OK. Used by CI/CD to wait for the backend to be ready before running E2E tests.
 
-## Static File Serving (Production)
+## Frontend Serving
 
-When not in development and `NO_FRONTEND` is not set, the backend serves the Angular build from `Appy-frontend/dist/` and falls back all unmatched routes to `index.html` (for Angular's client-side routing).
+The backend **never builds the frontend**.
+
+- **Development**: the backend does not serve the frontend at all — run it manually with `npx ng serve` (→ `http://localhost:4200`).
+- **Production**: the backend serves the pre-built Angular files from `Appy-frontend/build/` and falls back all unmatched routes to `index.html` (for Angular's client-side routing). The Docker build builds the frontend in a separate stage and copies the output into the image.

--- a/Appy/Dockerfile
+++ b/Appy/Dockerfile
@@ -1,11 +1,16 @@
 # Dockerfile
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+# --- Build the Angular frontend ---
+FROM --platform=$BUILDPLATFORM node:18 AS frontend-build
+WORKDIR /app/Appy-frontend
+COPY Appy-frontend/package.json Appy-frontend/package-lock.json ./
+RUN npm ci
+COPY Appy-frontend/ ./
+RUN npm run build
+
+# --- Build the .NET backend (does not build the frontend) ---
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS backend-build
 WORKDIR /app
-RUN apt-get update -yq \
-    && apt-get install curl gnupg -yq \
-    && curl -sL https://deb.nodesource.com/setup_16.x | bash \
-    && apt-get install nodejs -yq
 
 # Copy csproj and restore as distinct layers
 COPY *.csproj ./
@@ -15,13 +20,16 @@ RUN dotnet restore
 COPY . .
 RUN dotnet publish -c Release -o out
 
-# Build runtime image
+# --- Runtime image ---
 FROM mcr.microsoft.com/dotnet/aspnet:8.0
 WORKDIR /app
 RUN apt-get update -yq \
     && apt-get install curl -yq
 
-COPY --from=build-env /app/out .
+COPY --from=backend-build /app/out .
+# Serve the pre-built frontend from the path the backend expects (spaPath in Program.cs)
+COPY --from=frontend-build /app/Appy-frontend/build ./Appy-frontend/build
+
 ENTRYPOINT ["dotnet", "Appy.dll"]
 
 HEALTHCHECK --interval=10s --timeout=10s --start-period=30s --retries=2 CMD curl --fail http://localhost:80/health || exit 1

--- a/Appy/Program.cs
+++ b/Appy/Program.cs
@@ -3,7 +3,6 @@ using Appy.Exceptions;
 using Appy.Services;
 using Appy.Services.Facilities;
 using Appy.Services.MessagingServices;
-using Microsoft.AspNetCore.SpaServices.AngularCli;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 var builder = WebApplication.CreateBuilder(args);
@@ -75,11 +74,17 @@ builder.Services.AddHealthChecks().AddCheck("self", () => HealthCheckResult.Heal
 
 var app = builder.Build();
 
-var useLocalSPA = app.Environment.IsDevelopment() && Environment.GetEnvironmentVariable("NO_FRONTEND") != "true";
+// In development the frontend is run manually by the developer (npx ng serve) and the
+// backend does not serve it at all. In production the backend serves the pre-built frontend.
+var serveFrontend = !app.Environment.IsDevelopment();
 
 app.UseHttpsRedirection();
-app.UseStaticFiles();
-app.UseSpaStaticFiles();
+
+if (serveFrontend)
+{
+    app.UseStaticFiles();
+    app.UseSpaStaticFiles();
+}
 
 app.UseRouting();
 
@@ -103,7 +108,7 @@ app.UseEndpoints(endpoints =>
     endpoints.MapControllers();
     endpoints.MapHealthChecks("/health");
 
-    if (!useLocalSPA)
+    if (serveFrontend)
     {
         // Explicit Fallback to index.html in SpaStaticFiles directory
         endpoints.MapFallback(async context =>
@@ -124,16 +129,6 @@ app.UseEndpoints(endpoints =>
         });
     }
 });
-
-if (useLocalSPA)
-{
-    app.UseSpa(spa =>
-    {
-        spa.Options.SourcePath = "Appy-frontend";
-
-        spa.UseAngularCliServer(npmScript: "start");
-    });
-}
 
 using (var scope = app.Services.CreateScope())
 {

--- a/Appy/Properties/launchSettings.json
+++ b/Appy/Properties/launchSettings.json
@@ -11,19 +11,12 @@
   "profiles": {
     "Appy": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "dotnetRunMessages": true
-    },
-    "NoFrontend": {
-      "commandName": "Project",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "NO_FRONTEND": "true"
-      }
     }
   }
 }


### PR DESCRIPTION
Closes #109.

## What & why

The backend should never build the frontend. The split is now purely environment-based:

- **Development** — the frontend is run manually by the developer (`npx ng serve` → `http://localhost:4200`). The backend does **not** serve or build the frontend at all.
- **Production** — the backend serves the already-built frontend files (as before).

This makes the `NO_FRONTEND` env var redundant, so it's gone.

## Changes

- **`Program.cs`** — replace `useLocalSPA` (dev + `NO_FRONTEND`) with `serveFrontend = !IsDevelopment()`. Removed the `UseSpa` / `UseAngularCliServer` block, so the backend never starts the Angular CLI. Static files + `index.html` fallback now wire up only in production.
- **`Appy.csproj`** — removed both frontend-touching MSBuild targets: `DebugEnsureNodeEnv` (npm install on Debug build) and `PublishRunWebpack` (npm build during `dotnet publish`).
- **`Dockerfile`** — build the frontend in a dedicated `node:18` stage; the dotnet build stage no longer installs Node or builds the SPA. The runtime image copies the pre-built frontend into the path the backend serves (`Appy-frontend/build`).
- **`.dockerignore`** — exclude frontend `node_modules/`, `build/`, `.angular/`.
- **`launchSettings.json`** — removed the `NoFrontend` profile; set `launchBrowser: false` (the dev backend no longer serves a frontend).
- **`e2e_on_pr.yml`** — dropped `NO_FRONTEND: true` (Development already no longer serves the SPA).
- **CLAUDE.md** (backend + cypress) — docs updated.

## Verification

- `dotnet build` — clean (0 warnings, 0 errors).
- **Dev mode** (`ASPNETCORE_ENVIRONMENT=Development`): `/health` → 200, SPA route `/login` → **404** (frontend not served); startup log shows no npm/Angular CLI activity.
- **Prod mode** (`ASPNETCORE_ENVIRONMENT=Production`): `/health` → 200, `/login` → **200** serving the built `index.html` fallback.
- **E2E**: full Cypress suite passes (35/35) against the new backend + separately-run frontend.