### PR TITLE
feat: structured backend logging across the API (#87)

### DIFF
--- a/Appy.Tests/CLAUDE.md
+++ b/Appy.Tests/CLAUDE.md
@@ -12,7 +12,7 @@ Tests live in `Services/` and `Utils/`. The `Services/` tests cover three servic
 
 - **AppointmentServiceTests**: verifies the status-revert rule on `Edit` — a `Confirmed` appointment whose date, time, service, or client changes is reset to `Unconfirmed`; other statuses are preserved; duration- and notes-only edits leave the status alone. Also asserts that `AddNew` creates appointments in the `Unconfirmed` state.
 
-- **ClientNotificationServiceTests**: verifies contact validation (at least one contact required), Instagram IGSID lookup and `AppSpecificID` caching behavior, message template variable substitution (`{clientName}`, `{service}`, etc.), and multi-contact routing (stops at the first successful send).
+- **ClientNotificationServiceTests**: verifies contact validation (at least one contact required), Instagram IGSID lookup and `AppSpecificID` caching behavior, message template variable substitution (`{clientName}`, `{service}`, etc.), multi-contact routing (stops at the first successful send), and that a `LogLevel.Warning` is emitted when all contacts fail.
 
 ## How to Run
 

--- a/Appy.Tests/Exceptions/ExceptionMiddlewareTests.cs
+++ b/Appy.Tests/Exceptions/ExceptionMiddlewareTests.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using System.Text;
+using Appy.Exceptions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Appy.Tests.Exceptions
+{
+    public class ExceptionMiddlewareTests
+    {
+        private static void VerifyLogged(Mock<ILogger<ExceptionMiddleware>> logger, LogLevel level)
+        {
+            logger.Verify(x => x.Log(
+                level,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()),
+                Times.Once);
+        }
+
+        private static DefaultHttpContext ContextWithBody()
+        {
+            var context = new DefaultHttpContext();
+            context.Request.Method = "POST";
+            context.Request.Path = "/api/test";
+            context.Response.Body = new MemoryStream();
+            return context;
+        }
+
+        private static string ReadBody(HttpContext context)
+        {
+            context.Response.Body.Position = 0;
+            return new StreamReader(context.Response.Body, Encoding.UTF8).ReadToEnd();
+        }
+
+        [Fact]
+        public async Task ClientError_LogsInformation_AndWritesStatusAndMessage()
+        {
+            var logger = new Mock<ILogger<ExceptionMiddleware>>();
+            logger.Setup(x => x.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+            var middleware = new ExceptionMiddleware(
+                _ => throw new BadRequestException("BAD"), logger.Object);
+            var context = ContextWithBody();
+
+            await middleware.InvokeAsync(context);
+
+            Assert.Equal((int)HttpStatusCode.BadRequest, context.Response.StatusCode);
+            Assert.Equal("BAD", ReadBody(context));
+            VerifyLogged(logger, LogLevel.Information);
+        }
+
+        [Fact]
+        public async Task UnhandledException_LogsError_AndReturnsGeneric500()
+        {
+            var logger = new Mock<ILogger<ExceptionMiddleware>>();
+            logger.Setup(x => x.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+            var middleware = new ExceptionMiddleware(
+                _ => throw new InvalidOperationException("secret details"), logger.Object);
+            var context = ContextWithBody();
+
+            await middleware.InvokeAsync(context);
+
+            Assert.Equal(500, context.Response.StatusCode);
+            Assert.DoesNotContain("secret details", ReadBody(context));
+            VerifyLogged(logger, LogLevel.Error);
+        }
+    }
+}

--- a/Appy.Tests/Middleware/RequestLoggingMiddlewareTests.cs
+++ b/Appy.Tests/Middleware/RequestLoggingMiddlewareTests.cs
@@ -1,0 +1,56 @@
+using Appy.Middleware;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Appy.Tests.Middleware
+{
+    public class RequestLoggingMiddlewareTests
+    {
+        private static Mock<ILogger<RequestLoggingMiddleware>> VerifiableLogger()
+        {
+            var mock = new Mock<ILogger<RequestLoggingMiddleware>>();
+            mock.Setup(x => x.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+            return mock;
+        }
+
+        private static void VerifyLogged(Mock<ILogger<RequestLoggingMiddleware>> logger, LogLevel level)
+        {
+            logger.Verify(x => x.Log(
+                level,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Invoke_LogsInformation_OnSuccess()
+        {
+            var logger = VerifiableLogger();
+            var middleware = new RequestLoggingMiddleware(ctx => { ctx.Response.StatusCode = 200; return Task.CompletedTask; }, logger.Object);
+            var context = new DefaultHttpContext();
+            context.Request.Method = "GET";
+            context.Request.Path = "/api/test";
+
+            await middleware.Invoke(context);
+
+            VerifyLogged(logger, LogLevel.Information);
+        }
+
+        [Fact]
+        public async Task Invoke_LogsError_OnServerError()
+        {
+            var logger = VerifiableLogger();
+            var middleware = new RequestLoggingMiddleware(ctx => { ctx.Response.StatusCode = 500; return Task.CompletedTask; }, logger.Object);
+            var context = new DefaultHttpContext();
+            context.Request.Method = "POST";
+            context.Request.Path = "/api/test";
+
+            await middleware.Invoke(context);
+
+            VerifyLogged(logger, LogLevel.Error);
+        }
+    }
+}

--- a/Appy.Tests/Services/AppointmentServiceTests.cs
+++ b/Appy.Tests/Services/AppointmentServiceTests.cs
@@ -1,6 +1,7 @@
 using Appy.Domain;
 using Appy.DTOs;
 using Appy.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Moq.EntityFrameworkCore;
 
@@ -44,7 +45,7 @@ namespace Appy.Tests.Services
                 .Setup(x => x.GetWorkingHours(It.IsAny<DateOnly>(), FacilityId))
                 .ReturnsAsync(allDays);
 
-            service = new AppointmentService(dbContextMock.Object, workingHourServiceMock.Object);
+            service = new AppointmentService(dbContextMock.Object, workingHourServiceMock.Object, NullLogger<AppointmentService>.Instance);
         }
 
         private Appointment AddAppointment(AppointmentStatus status)

--- a/Appy.Tests/Services/ClientNotificationServiceTests.cs
+++ b/Appy.Tests/Services/ClientNotificationServiceTests.cs
@@ -2,6 +2,7 @@
 using Appy.Exceptions;
 using Appy.Services;
 using Appy.Services.MessagingServices;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace Appy.Tests.Services
@@ -11,6 +12,7 @@ namespace Appy.Tests.Services
         private Mock<MainDbContext> dbContextMock;
         private Mock<IMessagingService> messagingServiceMock;
         private Mock<IMessagingServiceManager> messagingServiceManagerMock;
+        private Mock<ILogger<ClientNotificationsService>> loggerMock;
         private ClientNotificationsService service;
 
         private const string accessToken = "token";
@@ -29,7 +31,9 @@ namespace Appy.Tests.Services
             messagingServiceManagerMock.Setup(x => x.GetAccessToken(It.IsAny<ContactType>(), It.IsAny<ClientNotificationsSettings>())).Returns(accessToken);
             messagingServiceManagerMock.Setup(x => x.GetService(It.IsAny<ContactType>())).Returns(messagingServiceMock.Object);
 
-            service = new ClientNotificationsService(dbContextMock.Object, messagingServiceManagerMock.Object);
+            loggerMock = new Mock<ILogger<ClientNotificationsService>>();
+
+            service = new ClientNotificationsService(dbContextMock.Object, messagingServiceManagerMock.Object, loggerMock.Object);
         }
 
         [Fact]
@@ -177,6 +181,33 @@ namespace Appy.Tests.Services
 
             messagingServiceMock.Verify(x => x.SendMessage(accessToken, appSpecificID1, message), Times.Once);
             messagingServiceMock.Verify(x => x.SendMessage(accessToken, appSpecificID2, message), Times.Never);
+        }
+
+        [Fact]
+        public async Task SendMessageTo_LogsWarning_WhenAllContactsFail()
+        {
+            var message = "message";
+            var appSpecificID = "12311111";
+            var client = new Client
+            {
+                Id = 42,
+                Contacts = new List<ClientContact>
+                {
+                    new() { Type = ContactType.Instagram, Value = "123", AppSpecificID = appSpecificID }
+                }
+            };
+
+            messagingServiceMock.Setup(x => x.SendMessage(accessToken, appSpecificID, message)).ReturnsAsync(false);
+
+            await Assert.ThrowsAsync<BadRequestException>(() => service.SendMessageTo(new ClientNotificationsSettings(), client, message));
+
+            loggerMock.Verify(x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()),
+                Times.Once);
         }
     }
 }

--- a/Appy/Auth/JwtMiddleware.cs
+++ b/Appy/Auth/JwtMiddleware.cs
@@ -2,6 +2,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Threading.Tasks;
+using Appy.Domain;
 using Appy.Services;
 
 namespace Appy.Auth
@@ -10,11 +11,13 @@ namespace Appy.Auth
     {
         private readonly RequestDelegate _next;
         private readonly IJwtService jwtService;
+        private readonly ILogger<JwtMiddleware> logger;
 
-        public JwtMiddleware(RequestDelegate next, IJwtService jwtService)
+        public JwtMiddleware(RequestDelegate next, IJwtService jwtService, ILogger<JwtMiddleware> logger)
         {
             _next = next;
             this.jwtService = jwtService;
+            this.logger = logger;
         }
 
         public async Task Invoke(HttpContext context, IUserService userService)
@@ -24,7 +27,17 @@ namespace Appy.Auth
             if (token != null)
                 await AttachUserToContext(context, userService, token);
 
-            await _next(context);
+            if (context.Items["User"] is User user)
+            {
+                using (logger.BeginScope(new Dictionary<string, object> { ["UserId"] = user.Id }))
+                {
+                    await _next(context);
+                }
+            }
+            else
+            {
+                await _next(context);
+            }
         }
 
         private async Task AttachUserToContext(HttpContext context, IUserService userService, string token)

--- a/Appy/CLAUDE.md
+++ b/Appy/CLAUDE.md
@@ -47,6 +47,8 @@ All application services are registered as **Scoped**. The one exception is `Cro
 
 Built-in `Microsoft.Extensions.Logging`. Console providers are configured in `Program.cs`: readable single-line console + Debug in Development, JSON console in Production. `IncludeScopes` is on, so correlation scopes appear in output. Per-category levels live in `appsettings*.json` (`Microsoft.EntityFrameworkCore` is pinned to Warning to suppress per-SQL noise; `Appy` is Information in prod, Debug in dev).
 
+**EF Core logging**: `MainDbContext` does **not** call `UseLoggerFactory` — because the context is registered via `AddDbContext`, EF Core automatically uses the application's `ILoggerFactory`, so EF logs flow through the same providers and honor the `Microsoft.EntityFrameworkCore` level above. (Never pass a per-instance `LoggerFactory` from `OnConfiguring` — it leaks and bypasses the pipeline.) In Development only, `AddDbContext` enables `EnableSensitiveDataLogging` + `EnableDetailedErrors`; raise the EF level to Information in `appsettings.Development.json` to see parameterized SQL.
+
 **Correlation scopes** are opened by middleware: `RequestId` (RequestLoggingMiddleware), `UserId` (JwtMiddleware), `FacilityId` (FacilityMiddleware). Downstream logs inherit them — don't repeat these ids in messages.
 
 **Levels:** Debug = diagnostic detail; Information = significant business events (create/update/delete, login/logout, notification sent); Warning = handled failures + security signals (failed login, refresh-token reuse, notification send failure); Error = unexpected/unhandled exceptions and 5xx. Always use message templates, never string interpolation.

--- a/Appy/CLAUDE.md
+++ b/Appy/CLAUDE.md
@@ -18,14 +18,16 @@ ASP.NET Core 8 Web API. Serves the REST API and, in production, also serves the 
 | `Auth/` | `Auth/CLAUDE.md` |
 | `Exceptions/` | `Exceptions/CLAUDE.md` |
 | `Utils/` | `Utils/CLAUDE.md` |
+| `Middleware/` | `Middleware/CLAUDE.md` |
 
 ## Request Pipeline (order matters)
 
 ```
 Request
-  → ExceptionMiddleware       (catches HttpException → JSON response)
-  → JwtMiddleware             (validates Bearer token → attaches User to HttpContext.Items)
-  → FacilityMiddleware        (reads facility-id header → stores in HttpContext.Items)
+  → RequestLoggingMiddleware  (opens RequestId scope; logs method/path/status/elapsed)
+  → ExceptionMiddleware       (logs by severity; HttpException → JSON; unhandled → generic 500)
+  → JwtMiddleware             (validates Bearer token → attaches User; opens UserId scope)
+  → FacilityMiddleware        (reads facility-id header → stores in HttpContext.Items; opens FacilityId scope)
   → [AuthorizeAttribute]      (action filter: 401 if no user)
   → [SelectedFacilityAttribute] (action filter: validates ownership, 400/404)
   → Controller Action
@@ -40,6 +42,14 @@ All application services are registered as **Scoped**. The one exception is `Cro
 - **Development**: `appsettings.json`
 - **Production**: environment variables (UPPER_SNAKE_CASE — see `Utils/CLAUDE.md`)
 - `NO_FRONTEND=true` env var skips static file serving (used in CI)
+
+## Logging
+
+Built-in `Microsoft.Extensions.Logging`. Console providers are configured in `Program.cs`: readable single-line console + Debug in Development, JSON console in Production. `IncludeScopes` is on, so correlation scopes appear in output. Per-category levels live in `appsettings*.json` (`Microsoft.EntityFrameworkCore` is pinned to Warning to suppress per-SQL noise; `Appy` is Information in prod, Debug in dev).
+
+**Correlation scopes** are opened by middleware: `RequestId` (RequestLoggingMiddleware), `UserId` (JwtMiddleware), `FacilityId` (FacilityMiddleware). Downstream logs inherit them — don't repeat these ids in messages.
+
+**Levels:** Debug = diagnostic detail; Information = significant business events (create/update/delete, login/logout, notification sent); Warning = handled failures + security signals (failed login, refresh-token reuse, notification send failure); Error = unexpected/unhandled exceptions and 5xx. Always use message templates, never string interpolation.
 
 ## Database
 

--- a/Appy/Domain/MainDbContext.cs
+++ b/Appy/Domain/MainDbContext.cs
@@ -24,7 +24,11 @@ namespace Appy.Domain
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseLoggerFactory(LoggerFactory.Create(b => b.AddFilter((category, level) => level > LogLevel.Information)));
+            // Do NOT call UseLoggerFactory here: when the context is registered via AddDbContext,
+            // EF Core automatically uses the application's ILoggerFactory, so EF logs flow through
+            // the configured console/JSON providers and honor the Microsoft.EntityFrameworkCore
+            // log level from appsettings. Creating a per-instance LoggerFactory would leak memory
+            // (a new factory per context instance) and bypass that pipeline.
             optionsBuilder.UseExceptionProcessor();
             optionsBuilder.UseNpgsql();
         }

--- a/Appy/Exceptions/CLAUDE.md
+++ b/Appy/Exceptions/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Exception System (Exceptions/)
 
-Custom exception hierarchy that maps to HTTP status codes. `ExceptionMiddleware` (registered in `Program.cs`) catches every `HttpException` and serializes it to a JSON response — controllers and services never catch these themselves.
+Custom exception hierarchy that maps to HTTP status codes. `ExceptionMiddleware` (registered in `Program.cs`) catches every `HttpException` and serializes it to a JSON response — controllers and services never catch these themselves. The middleware also logs `HttpException` by severity (4xx/client errors at Information, 5xx at Error), and additionally catches any unhandled non-`HttpException` exception, logs it at Error with the full stack trace, and returns a generic `500` response with body `"An unexpected error occurred"` that does not leak exception details.
 
 ## Hierarchy
 

--- a/Appy/Exceptions/ExceptionMiddleware.cs
+++ b/Appy/Exceptions/ExceptionMiddleware.cs
@@ -1,15 +1,9 @@
-﻿using Appy.DTOs;
-using Microsoft.AspNetCore.Http.Json;
-using Microsoft.Extensions.Options;
-using System.Net;
-using System.Text.Json;
-
-namespace Appy.Exceptions
+﻿namespace Appy.Exceptions
 {
     public class ExceptionMiddleware
     {
         private readonly RequestDelegate _next;
-        private readonly ILogger _logger;
+        private readonly ILogger<ExceptionMiddleware> _logger;
 
         public ExceptionMiddleware(RequestDelegate next, ILogger<ExceptionMiddleware> logger)
         {
@@ -25,16 +19,27 @@ namespace Appy.Exceptions
             }
             catch (HttpException ex)
             {
-                _logger.LogError($"Something went wrong: {ex}");
-                await HandleExceptionAsync(httpContext, ex);
-            }
-        }
+                var statusCode = (int)ex.StatusCode;
+                if (statusCode >= 500)
+                    _logger.LogError(ex, "Request failed: {Method} {Path} -> {StatusCode}",
+                        httpContext.Request.Method, httpContext.Request.Path.Value, statusCode);
+                else
+                    _logger.LogInformation("Request rejected: {Method} {Path} -> {StatusCode} ({Message})",
+                        httpContext.Request.Method, httpContext.Request.Path.Value, statusCode, ex.Message);
 
-        private async Task HandleExceptionAsync(HttpContext context, HttpException exception)
-        {
-            context.Response.ContentType = "application/json";
-            context.Response.StatusCode = (int)exception.StatusCode;
-            await context.Response.WriteAsync(exception.Message);
+                httpContext.Response.ContentType = "application/json";
+                httpContext.Response.StatusCode = statusCode;
+                await httpContext.Response.WriteAsync(ex.Message);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unhandled exception: {Method} {Path}",
+                    httpContext.Request.Method, httpContext.Request.Path.Value);
+
+                httpContext.Response.ContentType = "application/json";
+                httpContext.Response.StatusCode = 500;
+                await httpContext.Response.WriteAsync("An unexpected error occurred");
+            }
         }
     }
 }

--- a/Appy/Middleware/CLAUDE.md
+++ b/Appy/Middleware/CLAUDE.md
@@ -1,7 +1,12 @@
 # CLAUDE.md — Request Middleware (Middleware/)
 
-Cross-cutting middleware. See `Appy/CLAUDE.md` for the full pipeline (expanded in Task 10).
+Cross-cutting middleware that isn't tied to one feature folder. (Auth and facility middleware live under `Auth/` and `Services/Facilities/` respectively; the exception middleware lives under `Exceptions/`.)
 
 ## RequestLoggingMiddleware
 
-Outermost middleware. Opens a logging scope with `RequestId` (= `HttpContext.TraceIdentifier`) and logs one summary line per request (method, path, status, elapsed ms). Information for `< 500`, Error for `5xx`.
+Registered **outermost** in the pipeline (before `ExceptionMiddleware`). For each request it:
+- Opens a logging scope with `RequestId` = `HttpContext.TraceIdentifier`, so every log emitted while handling the request is correlated.
+- Times the request and logs one summary line on completion: method, path, status code, elapsed ms.
+- Picks the level by outcome: `< 500` → Information, `5xx` → Error.
+
+See `Appy/CLAUDE.md` → Logging for the level conventions and the other correlation scopes (`UserId`, `FacilityId`).

--- a/Appy/Middleware/CLAUDE.md
+++ b/Appy/Middleware/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md — Request Middleware (Middleware/)
+
+Cross-cutting middleware. See `Appy/CLAUDE.md` for the full pipeline (expanded in Task 10).
+
+## RequestLoggingMiddleware
+
+Outermost middleware. Opens a logging scope with `RequestId` (= `HttpContext.TraceIdentifier`) and logs one summary line per request (method, path, status, elapsed ms). Information for `< 500`, Error for `5xx`.

--- a/Appy/Middleware/CLAUDE.md
+++ b/Appy/Middleware/CLAUDE.md
@@ -4,7 +4,7 @@ Cross-cutting middleware that isn't tied to one feature folder. (Auth and facili
 
 ## RequestLoggingMiddleware
 
-Registered **outermost** in the pipeline (before `ExceptionMiddleware`). For each request it:
+Registered as the first application middleware — immediately before `ExceptionMiddleware`, after the framework infrastructure (HTTPS redirect, static-file/SPA serving, routing). It therefore wraps `ExceptionMiddleware` and covers all controller/API traffic, but intentionally does not log static-asset responses. For each request it:
 - Opens a logging scope with `RequestId` = `HttpContext.TraceIdentifier`, so every log emitted while handling the request is correlated.
 - Times the request and logs one summary line on completion: method, path, status code, elapsed ms.
 - Picks the level by outcome: `< 500` → Information, `5xx` → Error.

--- a/Appy/Middleware/RequestLoggingMiddleware.cs
+++ b/Appy/Middleware/RequestLoggingMiddleware.cs
@@ -1,0 +1,45 @@
+using System.Diagnostics;
+
+namespace Appy.Middleware
+{
+    public class RequestLoggingMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<RequestLoggingMiddleware> _logger;
+
+        public RequestLoggingMiddleware(RequestDelegate next, ILogger<RequestLoggingMiddleware> logger)
+        {
+            _next = next;
+            _logger = logger;
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            var stopwatch = Stopwatch.StartNew();
+
+            using (_logger.BeginScope(new Dictionary<string, object>
+            {
+                ["RequestId"] = context.TraceIdentifier
+            }))
+            {
+                try
+                {
+                    await _next(context);
+                }
+                finally
+                {
+                    stopwatch.Stop();
+
+                    var statusCode = context.Response.StatusCode;
+                    var level = statusCode >= 500 ? LogLevel.Error : LogLevel.Information;
+
+                    _logger.Log(level, "HTTP {Method} {Path} responded {StatusCode} in {ElapsedMs}ms",
+                        context.Request.Method,
+                        context.Request.Path.Value,
+                        statusCode,
+                        stopwatch.ElapsedMilliseconds);
+                }
+            }
+        }
+    }
+}

--- a/Appy/Program.cs
+++ b/Appy/Program.cs
@@ -8,6 +8,21 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 var builder = WebApplication.CreateBuilder(args);
 
+builder.Logging.ClearProviders();
+if (builder.Environment.IsDevelopment())
+{
+    builder.Logging.AddSimpleConsole(o =>
+    {
+        o.IncludeScopes = true;
+        o.SingleLine = true;
+    });
+    builder.Logging.AddDebug();
+}
+else
+{
+    builder.Logging.AddJsonConsole(o => o.IncludeScopes = true);
+}
+
 var jwtSecret = builder.Configuration["JwtSecret"];
 if (string.IsNullOrEmpty(jwtSecret))
     throw new InvalidOperationException(

--- a/Appy/Program.cs
+++ b/Appy/Program.cs
@@ -75,7 +75,7 @@ builder.Services.AddScheduler(config =>
         var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("CronJobs");
         return (sender, args) =>
         {
-            logger?.LogError(args.Exception?.Message);
+            logger?.LogError(args.Exception, "Unobserved task exception in scheduled job");
             args.SetObserved();
         };
     });

--- a/Appy/Program.cs
+++ b/Appy/Program.cs
@@ -32,7 +32,18 @@ var spaPath = "Appy-frontend/build";
 
 // Add services to the container.
 builder.Services.AddDbContext<MainDbContext>(options =>
-    options.UseNpgsql(builder.Configuration.GetConnectionString("Main")));
+{
+    options.UseNpgsql(builder.Configuration.GetConnectionString("Main"));
+
+    if (builder.Environment.IsDevelopment())
+    {
+        // Dev-only EF diagnostics. EnableSensitiveDataLogging includes SQL parameter values
+        // in logs, so it must never run in production. These take effect when the
+        // Microsoft.EntityFrameworkCore log level is raised to Information in appsettings.Development.json.
+        options.EnableSensitiveDataLogging();
+        options.EnableDetailedErrors();
+    }
+});
 builder.Services.AddSingleton<IJwtService, JwtService>();
 
 builder.Services.AddHttpClient<InstagramMessagingService>(client =>

--- a/Appy/Program.cs
+++ b/Appy/Program.cs
@@ -107,6 +107,7 @@ if (app.Environment.IsDevelopment())
         .WithOrigins("http://localhost:4200"));
 }
 
+app.UseMiddleware<Appy.Middleware.RequestLoggingMiddleware>();
 app.UseMiddleware<ExceptionMiddleware>();
 app.UseMiddleware<Appy.Auth.JwtMiddleware>();
 app.UseMiddleware<FacilityMiddleware>();

--- a/Appy/Services/AppointmentReminderService.cs
+++ b/Appy/Services/AppointmentReminderService.cs
@@ -83,6 +83,9 @@ namespace Appy.Services
                 .Where(a => a.Date == date && a.FacilityId == facilityId)
                 .ToListAsync();
 
+            int sent = 0;
+            int failed = 0;
+
             foreach (var appointment in appointments)
             {
                 if (appointment.Status != AppointmentStatus.Confirmed)
@@ -100,15 +103,21 @@ namespace Appy.Services
                     await this.clientNotificationsService.SendAppointmentReminderMessage(appointment.Client.Id, appointment.ToViewDTO(null), cultureInfo);
 
                     appointment.WasReminded = true;
+                    sent++;
                 }
                 catch (Exception ex)
                 {
-                    logger.LogError("Failed to send appointment reminder for appointmentId: {appointmentId} to clientId: {clientId} because: {exceptionMessage}",
-                        appointment.Id, appointment.Client.Id, ex.Message);
+                    failed++;
+                    logger.LogError(ex, "Failed to send appointment reminder for appointmentId {AppointmentId} to clientId {ClientId}",
+                        appointment.Id, appointment.Client.Id);
                 }
             }
 
             await dbContext.SaveChangesAsync();
+
+            if (sent > 0 || failed > 0)
+                logger.LogInformation("Reminder run for facilityId {FacilityId} on {Date}: {Sent} sent, {Failed} failed",
+                    facilityId, date, sent, failed);
         }
     }
 }

--- a/Appy/Services/AppointmentService.cs
+++ b/Appy/Services/AppointmentService.cs
@@ -3,6 +3,7 @@ using Appy.DTOs;
 using Appy.Exceptions;
 using Appy.Services.SmartFiltering;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 
@@ -30,10 +31,13 @@ namespace Appy.Services
 
         private IWorkingHourService workingHourService;
 
-        public AppointmentService(MainDbContext context, IWorkingHourService workingHourService)
+        private readonly ILogger<AppointmentService> logger;
+
+        public AppointmentService(MainDbContext context, IWorkingHourService workingHourService, ILogger<AppointmentService> logger)
         {
             this.context = context;
             this.workingHourService = workingHourService;
+            this.logger = logger;
         }
 
         public Task<List<AppointmentViewDTO>> GetAll(DateOnly date, int facilityId, bool findPrevious, SmartFilter? filter)
@@ -146,6 +150,9 @@ namespace Appy.Services
             context.Appointments.Add(appointment);
             await context.SaveChangesAsync();
 
+            logger.LogInformation("Appointment {AppointmentId} created for clientId {ClientId}, serviceId {ServiceId} on {Date} {Time} (facilityId {FacilityId})",
+                appointment.Id, client.Id, service.Id, appointment.Date, appointment.Time, facilityId);
+
             var previous = await GetPreviousAppointment(appointment);
 
             return appointment.ToViewDTO(previous);
@@ -198,6 +205,8 @@ namespace Appy.Services
 
             await context.SaveChangesAsync();
 
+            logger.LogInformation("Appointment {AppointmentId} updated (facilityId {FacilityId})", appointment.Id, facilityId);
+
             var previous = await GetPreviousAppointment(appointment);
 
             return appointment.ToViewDTO(previous);
@@ -215,6 +224,8 @@ namespace Appy.Services
 
             await context.SaveChangesAsync();
 
+            logger.LogInformation("Appointment {AppointmentId} status set to {Status} (facilityId {FacilityId})", appointment.Id, status, facilityId);
+
             var previous = await GetPreviousAppointment(appointment);
 
             return appointment.ToViewDTO(previous);
@@ -228,6 +239,8 @@ namespace Appy.Services
 
             context.Appointments.Remove(appointments);
             await context.SaveChangesAsync();
+
+            logger.LogInformation("Appointment {AppointmentId} deleted (facilityId {FacilityId})", id, facilityId);
         }
 
         public List<FreeTimeDTO> GetFreeTimes(List<AppointmentViewDTO> appointmentsOfTheDay, List<WorkingHour> workingHours, ServiceDTO service, TimeSpan duration)

--- a/Appy/Services/AppointmentService.cs
+++ b/Appy/Services/AppointmentService.cs
@@ -3,7 +3,6 @@ using Appy.DTOs;
 using Appy.Exceptions;
 using Appy.Services.SmartFiltering;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 

--- a/Appy/Services/CLAUDE.md
+++ b/Appy/Services/CLAUDE.md
@@ -14,7 +14,7 @@ Business logic layer. Each service corresponds to one domain concept and is cons
 | `AppointmentService` | Appointment CRUD, free-time slot generation, status changes, client notification dispatch |
 | `WorkingHourService` | Working-hour CRUD with overlap validation; replaces all hours for a facility atomically |
 | `DashboardService` | Dashboard settings upsert (unique per user + facility) |
-| `ClientNotificationsService` | Notification settings and outbound message dispatch |
+| `ClientNotificationsService` | Notification settings and outbound message dispatch; logs per-contact Debug detail, Information on success, Warning before throwing `MESSAGE_FAILED_TO_SEND` |
 | `AppointmentReminderService` | Cron job (every 5 minutes) — sends reminders for the next day's confirmed appointments |
 | `TestingService` | Dev-only data seeder, reachable via `TestingController` |
 

--- a/Appy/Services/CLAUDE.md
+++ b/Appy/Services/CLAUDE.md
@@ -32,3 +32,4 @@ Business logic layer. Each service corresponds to one domain concept and is cons
 - **Reminder deduplication**: `AppointmentReminderService` only reminds once per appointment (`WasReminded` flag prevents repeats across scheduler ticks)
 - **Contact name uniqueness**: `ClientService` enforces case-insensitive name + surname uniqueness per facility
 - **AppSpecificID preservation**: when a client's contacts are updated, existing `AppSpecificID` values are re-attached by matching contact type + value, so cached IGSIDs survive edits
+- **Logging**: services log significant mutations at Information and handled failures / security signals at Warning/Error, using `ILogger<T>` with message templates. Correlation ids (`RequestId`/`UserId`/`FacilityId`) come from middleware scopes — don't repeat them in messages. See `Appy/CLAUDE.md` → Logging.

--- a/Appy/Services/CLAUDE.md
+++ b/Appy/Services/CLAUDE.md
@@ -6,7 +6,7 @@ Business logic layer. Each service corresponds to one domain concept and is cons
 
 | Service | Responsibility |
 |---------|---------------|
-| `UserService` | Registration, authentication, token refresh, logout |
+| `UserService` | Registration, authentication, token refresh, logout. Logs: Warning on failed login (no-user, wrong-password) and refresh-token reuse detection; Information on login, register, logout; Debug on token rotation |
 | `JwtService` | JWT generation and validation (see `Auth/CLAUDE.md`) |
 | `FacilityService` | Facility CRUD, selected-facility management per user |
 | `ServiceService` | Service CRUD, archive toggle, name uniqueness enforcement |

--- a/Appy/Services/ClientNotificationsService.cs
+++ b/Appy/Services/ClientNotificationsService.cs
@@ -3,6 +3,7 @@ using Appy.DTOs;
 using Appy.Exceptions;
 using Appy.Services.MessagingServices;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using System.Globalization;
 
 namespace Appy.Services
@@ -22,10 +23,13 @@ namespace Appy.Services
 
         private IMessagingServiceManager messagingServiceManager;
 
-        public ClientNotificationsService(MainDbContext context, IMessagingServiceManager messagingServiceManager)
+        private readonly ILogger<ClientNotificationsService> logger;
+
+        public ClientNotificationsService(MainDbContext context, IMessagingServiceManager messagingServiceManager, ILogger<ClientNotificationsService> logger)
         {
             this.context = context;
             this.messagingServiceManager = messagingServiceManager;
+            this.logger = logger;
         }
 
         public async Task<ClientNotificationsSettings> GetSettings(int facilityId)
@@ -82,67 +86,99 @@ namespace Appy.Services
 
         public async Task SendAppointmentConfirmationMessage(int clientId, AppointmentViewDTO appointment, CultureInfo cultureInfo)
         {
-            var client = await context.Clients.FirstOrDefaultAsync(c => c.Id == clientId);
-            if (client == null)
-                throw new NotFoundException();
+            using (logger.BeginScope(new Dictionary<string, object>
+            {
+                ["AppointmentId"] = appointment.Id,
+                ["ClientId"] = clientId,
+                ["MessageType"] = "AppointmentConfirmation"
+            }))
+            {
+                var client = await context.Clients.FirstOrDefaultAsync(c => c.Id == clientId);
+                if (client == null)
+                    throw new NotFoundException();
 
-            var facility = await context.Facilities.Include(f => f.ClientNotificationsSettings).FirstOrDefaultAsync(f => f.Id == client.FacilityId);
-            if (facility == null)
-                throw new NotFoundException();
+                var facility = await context.Facilities.Include(f => f.ClientNotificationsSettings).FirstOrDefaultAsync(f => f.Id == client.FacilityId);
+                if (facility == null)
+                    throw new NotFoundException();
 
-            var settings = facility.ClientNotificationsSettings;
+                var settings = facility.ClientNotificationsSettings;
 
-            var message = settings?.AppointmentConfirmationMessageTemplate;
-            if (settings == null || string.IsNullOrEmpty(message))
-                throw new BadRequestException("Appointment confirmation message template is not set");
+                var message = settings?.AppointmentConfirmationMessageTemplate;
+                if (settings == null || string.IsNullOrEmpty(message))
+                    throw new BadRequestException("Appointment confirmation message template is not set");
 
-            message = FillInMessageTemplate(message, cultureInfo, client, appointment);
+                message = FillInMessageTemplate(message, cultureInfo, client, appointment);
 
-            await SendMessageTo(settings, client, message);
+                await SendMessageTo(settings, client, message);
+            }
         }
 
         public async Task SendAppointmentReminderMessage(int clientId, AppointmentViewDTO appointment, CultureInfo cultureInfo)
         {
-            var client = await context.Clients.FirstOrDefaultAsync(c => c.Id == clientId);
-            if (client == null)
-                throw new NotFoundException();
+            using (logger.BeginScope(new Dictionary<string, object>
+            {
+                ["AppointmentId"] = appointment.Id,
+                ["ClientId"] = clientId,
+                ["MessageType"] = "AppointmentReminder"
+            }))
+            {
+                var client = await context.Clients.FirstOrDefaultAsync(c => c.Id == clientId);
+                if (client == null)
+                    throw new NotFoundException();
 
-            var facility = await context.Facilities.Include(f => f.ClientNotificationsSettings).FirstOrDefaultAsync(f => f.Id == client.FacilityId);
-            if (facility == null)
-                throw new NotFoundException();
+                var facility = await context.Facilities.Include(f => f.ClientNotificationsSettings).FirstOrDefaultAsync(f => f.Id == client.FacilityId);
+                if (facility == null)
+                    throw new NotFoundException();
 
-            var settings = facility.ClientNotificationsSettings;
+                var settings = facility.ClientNotificationsSettings;
 
-            var message = settings?.AppointmentReminderMessageTemplate;
-            if (settings == null || string.IsNullOrEmpty(message))
-                throw new BadRequestException("Appointment reminder message template is not set");
+                var message = settings?.AppointmentReminderMessageTemplate;
+                if (settings == null || string.IsNullOrEmpty(message))
+                    throw new BadRequestException("Appointment reminder message template is not set");
 
-            message = FillInMessageTemplate(message, cultureInfo, client, appointment);
+                message = FillInMessageTemplate(message, cultureInfo, client, appointment);
 
-            await SendMessageTo(settings, client, message);
+                await SendMessageTo(settings, client, message);
+            }
         }
 
         public async Task SendMessageTo(ClientNotificationsSettings settings, Client client, string message)
         {
             if (client.Contacts == null || client.Contacts.Count == 0)
+            {
+                logger.LogWarning("Cannot send message to clientId {ClientId}: client has no contacts", client.Id);
                 throw new BadRequestException("Client has no contacts");
+            }
+
+            var triedContactTypes = new List<ContactType>();
 
             foreach (var contact in client.Contacts)
             {
                 if (!messagingServiceManager.IsSupported(contact.Type))
+                {
+                    logger.LogDebug("Skipping {ContactType} contact for clientId {ClientId}: type not supported", contact.Type, client.Id);
                     continue;
+                }
+
+                triedContactTypes.Add(contact.Type);
 
                 var messagingService = messagingServiceManager.GetService(contact.Type);
                 var accessToken = messagingServiceManager.GetAccessToken(contact.Type, settings);
 
                 if (string.IsNullOrEmpty(accessToken))
+                {
+                    logger.LogDebug("Skipping {ContactType} contact for clientId {ClientId}: no access token configured", contact.Type, client.Id);
                     continue;
+                }
 
                 if (string.IsNullOrEmpty(contact.AppSpecificID))
                 {
                     var appSpecificID = await messagingService.GetAppSpecificUserID(accessToken, contact.Value);
                     if (string.IsNullOrEmpty(appSpecificID))
+                    {
+                        logger.LogDebug("Skipping {ContactType} contact for clientId {ClientId}: could not resolve app-specific user ID", contact.Type, client.Id);
                         continue;
+                    }
 
                     context.Attach(contact);
 
@@ -153,8 +189,16 @@ namespace Appy.Services
 
                 var success = await messagingService.SendMessage(accessToken, contact.AppSpecificID, message);
                 if (success)
+                {
+                    logger.LogInformation("Message sent to clientId {ClientId} via {ContactType}", client.Id, contact.Type);
                     return;
+                }
+
+                logger.LogDebug("Send via {ContactType} for clientId {ClientId} returned failure", contact.Type, client.Id);
             }
+
+            logger.LogWarning("Failed to send message to clientId {ClientId}: all contacts exhausted (types tried: {ContactTypes})",
+                client.Id, string.Join(", ", triedContactTypes));
 
             throw new BadRequestException("pages.client-notifications.errors.MESSAGE_FAILED_TO_SEND");
         }

--- a/Appy/Services/ClientNotificationsService.cs
+++ b/Appy/Services/ClientNotificationsService.cs
@@ -3,7 +3,6 @@ using Appy.DTOs;
 using Appy.Exceptions;
 using Appy.Services.MessagingServices;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 using System.Globalization;
 
 namespace Appy.Services

--- a/Appy/Services/ClientService.cs
+++ b/Appy/Services/ClientService.cs
@@ -3,6 +3,7 @@ using Appy.DTOs;
 using Appy.Exceptions;
 using EntityFramework.Exceptions.Common;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace Appy.Services
 {
@@ -19,10 +20,12 @@ namespace Appy.Services
     public class ClientService : IClientService
     {
         private MainDbContext context;
+        private readonly ILogger<ClientService> logger;
 
-        public ClientService(MainDbContext context)
+        public ClientService(MainDbContext context, ILogger<ClientService> logger)
         {
             this.context = context;
+            this.logger = logger;
         }
 
         public Task<List<Client>> GetAll(int facilityId, bool archived)
@@ -49,8 +52,8 @@ namespace Appy.Services
         {
             var lowercaseSurname = dto.Surname?.ToLower();
 
-            var nameSurnameTaken = await context.Clients.Where(o => o.FacilityId == facilityId 
-                && o.Name.ToLower() == dto.Name.ToLower() 
+            var nameSurnameTaken = await context.Clients.Where(o => o.FacilityId == facilityId
+                && o.Name.ToLower() == dto.Name.ToLower()
                 && (o.Surname == null ? o.Surname : o.Surname.ToLower()) == lowercaseSurname).AnyAsync();
             if (nameSurnameTaken)
                 throw new ValidationException(nameof(Client.Surname), "pages.clients.errors.NAME_AND_SURNAME_TAKEN");
@@ -67,6 +70,8 @@ namespace Appy.Services
 
             context.Clients.Add(client);
             await context.SaveChangesAsync();
+
+            logger.LogInformation("Client {ClientId} created (facilityId {FacilityId})", client.Id, facilityId);
 
             return client;
         }
@@ -88,6 +93,8 @@ namespace Appy.Services
             client.IsArchived = dto.IsArchived;
             await context.SaveChangesAsync();
 
+            logger.LogInformation("Client {ClientId} updated (facilityId {FacilityId})", client.Id, facilityId);
+
             return client;
         }
 
@@ -101,6 +108,8 @@ namespace Appy.Services
             {
                 context.Clients.Remove(client);
                 await context.SaveChangesAsync();
+
+                logger.LogInformation("Client {ClientId} deleted (facilityId {FacilityId})", id, facilityId);
             }
             catch (ReferenceConstraintException)
             {
@@ -117,6 +126,8 @@ namespace Appy.Services
             client.IsArchived = isArchived;
 
             await context.SaveChangesAsync();
+
+            logger.LogInformation("Client {ClientId} archive set to {IsArchived} (facilityId {FacilityId})", client.Id, isArchived, facilityId);
 
             return client;
         }

--- a/Appy/Services/ClientService.cs
+++ b/Appy/Services/ClientService.cs
@@ -3,7 +3,6 @@ using Appy.DTOs;
 using Appy.Exceptions;
 using EntityFramework.Exceptions.Common;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 
 namespace Appy.Services
 {

--- a/Appy/Services/DashboardService.cs
+++ b/Appy/Services/DashboardService.cs
@@ -2,6 +2,7 @@
 using Appy.DTOs;
 using Appy.Exceptions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace Appy.Services
 {
@@ -14,10 +15,12 @@ namespace Appy.Services
     public class DashboardService : IDashboardService
     {
         private MainDbContext context;
+        private readonly ILogger<DashboardService> logger;
 
-        public DashboardService(MainDbContext context)
+        public DashboardService(MainDbContext context, ILogger<DashboardService> logger)
         {
             this.context = context;
+            this.logger = logger;
         }
 
         public async Task<DashboardSettings> GetSettings(int userId, int facilityId)
@@ -46,6 +49,8 @@ namespace Appy.Services
             settings.SettingsJSON = dto.SettingsJSON;
 
             await this.context.SaveChangesAsync();
+
+            logger.LogInformation("Dashboard settings saved for userId {UserId}, facilityId {FacilityId}", userId, facilityId);
 
             return settings;
         }

--- a/Appy/Services/DashboardService.cs
+++ b/Appy/Services/DashboardService.cs
@@ -2,7 +2,6 @@
 using Appy.DTOs;
 using Appy.Exceptions;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 
 namespace Appy.Services
 {

--- a/Appy/Services/Facilities/FacilityMiddleware.cs
+++ b/Appy/Services/Facilities/FacilityMiddleware.cs
@@ -3,16 +3,25 @@
     public class FacilityMiddleware
     {
         private readonly RequestDelegate _next;
+        private readonly ILogger<FacilityMiddleware> _logger;
 
-        public FacilityMiddleware(RequestDelegate next)
+        public FacilityMiddleware(RequestDelegate next, ILogger<FacilityMiddleware> logger)
         {
             _next = next;
+            _logger = logger;
         }
 
         public async Task Invoke(HttpContext context)
         {
             if (int.TryParse(context.Request.Headers["facility-id"].FirstOrDefault(), out int facilityId))
+            {
                 context.Items["facilityId"] = facilityId;
+                using (_logger.BeginScope(new Dictionary<string, object> { ["FacilityId"] = facilityId }))
+                {
+                    await _next(context);
+                }
+                return;
+            }
 
             await _next(context);
         }

--- a/Appy/Services/Facilities/FacilityService.cs
+++ b/Appy/Services/Facilities/FacilityService.cs
@@ -2,6 +2,7 @@
 using Appy.DTOs;
 using Appy.Exceptions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace Appy.Services.Facilities
 {
@@ -20,10 +21,12 @@ namespace Appy.Services.Facilities
     public class FacilityService : IFacilityService
     {
         private MainDbContext context;
+        private readonly ILogger<FacilityService> logger;
 
-        public FacilityService(MainDbContext context)
+        public FacilityService(MainDbContext context, ILogger<FacilityService> logger)
         {
             this.context = context;
+            this.logger = logger;
         }
 
         public async Task<Facility> AddNew(FacilityDTO dto, int ownerId)
@@ -37,6 +40,8 @@ namespace Appy.Services.Facilities
             context.Facilities.Add(facility);
             await context.SaveChangesAsync();
 
+            logger.LogInformation("Facility {FacilityId} '{Name}' created for ownerId {OwnerId}", facility.Id, facility.Name, ownerId);
+
             return facility;
         }
 
@@ -48,6 +53,8 @@ namespace Appy.Services.Facilities
 
             facility.Name = dto.Name;
             await context.SaveChangesAsync();
+
+            logger.LogInformation("Facility {FacilityId} updated by ownerId {OwnerId}", facilityId, ownerId);
 
             return facility;
         }
@@ -81,6 +88,8 @@ namespace Appy.Services.Facilities
 
             context.Facilities.Remove(facility);
             await context.SaveChangesAsync();
+
+            logger.LogInformation("Facility {FacilityId} deleted by userId {UserId}", facilityId, userId);
         }
 
         public async Task SetSelectedFacility(int userId, int facilityId)

--- a/Appy/Services/Facilities/FacilityService.cs
+++ b/Appy/Services/Facilities/FacilityService.cs
@@ -2,7 +2,6 @@
 using Appy.DTOs;
 using Appy.Exceptions;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 
 namespace Appy.Services.Facilities
 {

--- a/Appy/Services/ServiceService.cs
+++ b/Appy/Services/ServiceService.cs
@@ -3,6 +3,7 @@ using Appy.DTOs;
 using Appy.Exceptions;
 using EntityFramework.Exceptions.Common;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 
 namespace Appy.Services
@@ -20,10 +21,12 @@ namespace Appy.Services
     public class ServiceService : IServiceService
     {
         private MainDbContext context;
+        private readonly ILogger<ServiceService> logger;
 
-        public ServiceService(MainDbContext context)
+        public ServiceService(MainDbContext context, ILogger<ServiceService> logger)
         {
             this.context = context;
+            this.logger = logger;
         }
 
         public Task<List<Service>> GetAll(int facilityId, bool archived)
@@ -58,6 +61,8 @@ namespace Appy.Services
             context.Services.Add(service);
             await context.SaveChangesAsync();
 
+            logger.LogInformation("Service {ServiceId} '{Name}' created (facilityId {FacilityId})", service.Id, service.Name, facilityId);
+
             return service;
         }
 
@@ -77,6 +82,8 @@ namespace Appy.Services
             service.ColorId = dto.ColorId;
             await context.SaveChangesAsync();
 
+            logger.LogInformation("Service {ServiceId} updated (facilityId {FacilityId})", service.Id, facilityId);
+
             return service;
         }
 
@@ -90,6 +97,8 @@ namespace Appy.Services
             {
                 context.Services.Remove(service);
                 await context.SaveChangesAsync();
+
+                logger.LogInformation("Service {ServiceId} deleted (facilityId {FacilityId})", id, facilityId);
             }
             catch (ReferenceConstraintException)
             {
@@ -106,6 +115,8 @@ namespace Appy.Services
             service.IsArchived = isArchived;
 
             await context.SaveChangesAsync();
+
+            logger.LogInformation("Service {ServiceId} archive set to {IsArchived} (facilityId {FacilityId})", service.Id, isArchived, facilityId);
 
             return service;
         }

--- a/Appy/Services/ServiceService.cs
+++ b/Appy/Services/ServiceService.cs
@@ -3,7 +3,6 @@ using Appy.DTOs;
 using Appy.Exceptions;
 using EntityFramework.Exceptions.Common;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 using Npgsql;
 
 namespace Appy.Services

--- a/Appy/Services/UserService.cs
+++ b/Appy/Services/UserService.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Cryptography.KeyDerivation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using Appy.Domain;

--- a/Appy/Services/UserService.cs
+++ b/Appy/Services/UserService.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Cryptography.KeyDerivation;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using Appy.Domain;
@@ -22,23 +23,31 @@ namespace Appy.Services
     {
         private MainDbContext context;
         private IJwtService jwtService;
+        private readonly ILogger<UserService> logger;
 
-        public UserService(MainDbContext mainDbContext, IJwtService jwtService)
+        public UserService(MainDbContext mainDbContext, IJwtService jwtService, ILogger<UserService> logger)
         {
             this.context = mainDbContext;
             this.jwtService = jwtService;
+            this.logger = logger;
         }
 
         public async Task<LogInResponseDTO> Authenticate(LogInDTO model, string userAgent)
         {
             var user = await context.Users.FirstOrDefaultAsync(x => x.Email == model.Email);
             if (user == null)
+            {
+                logger.LogWarning("Failed login attempt: no user with email {Email}", model.Email);
                 throw new NotFoundException();
+            }
 
             var passwordHash = HashPassword(model.Password, user.Salt);
 
             if (passwordHash != user.PasswordHash)
+            {
+                logger.LogWarning("Failed login attempt for userId {UserId}: wrong password", user.Id);
                 throw new BadRequestException();
+            }
 
             var accessToken = GenerateAccessJwtToken(user);
             var refreshTokenFamily = GenerateFamily();
@@ -52,6 +61,8 @@ namespace Appy.Services
                 User = user,
             });
             await context.SaveChangesAsync();
+
+            logger.LogInformation("User {UserId} logged in", user.Id);
 
             return new LogInResponseDTO()
             {
@@ -93,6 +104,8 @@ namespace Appy.Services
                 User = user,
             });
             await context.SaveChangesAsync();
+
+            logger.LogInformation("New user registered: userId {UserId} ({Email})", user.Id, user.Email);
 
             return new LogInResponseDTO()
             {
@@ -137,6 +150,8 @@ namespace Appy.Services
                     // so someone stole the refresh token!
                     if (currentFamily == receivedFamily)
                     {
+                        logger.LogWarning("Refresh token reuse detected for userId {UserId}; invalidating session family", userId);
+
                         // invalidate the whole family
                         user.LoginSessions.Remove(loginSession);
                         await context.SaveChangesAsync();
@@ -162,6 +177,8 @@ namespace Appy.Services
 
             loginSession.RefreshToken = newRefreshToken;
             await context.SaveChangesAsync();
+
+            logger.LogDebug("Refresh tokens rotated for userId {UserId}", userId);
 
             return new LogInResponseDTO()
             {
@@ -190,6 +207,8 @@ namespace Appy.Services
 
             user.LoginSessions.Remove(user.LoginSessions.Single());
             await context.SaveChangesAsync();
+
+            logger.LogInformation("User {UserId} logged out", userId);
         }
 
         public async Task<User> GetById(int id)

--- a/Appy/Services/WorkingHourService.cs
+++ b/Appy/Services/WorkingHourService.cs
@@ -2,6 +2,7 @@
 using Appy.DTOs;
 using Appy.Exceptions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace Appy.Services
 {
@@ -16,10 +17,12 @@ namespace Appy.Services
     public class WorkingHourService : IWorkingHourService
     {
         private MainDbContext context;
+        private readonly ILogger<WorkingHourService> logger;
 
-        public WorkingHourService(MainDbContext context)
+        public WorkingHourService(MainDbContext context, ILogger<WorkingHourService> logger)
         {
             this.context = context;
+            this.logger = logger;
         }
 
         public Task<List<WorkingHour>> GetAll(int facilityId)
@@ -32,7 +35,7 @@ namespace Appy.Services
             return context.WorkingHours.Where(w => w.FacilityId == facilityId && w.DayOfWeek == date.DayOfWeek).ToListAsync();
         }
 
-        public Task SetWorkingHours(List<WorkingHourDTO> workingHours, int facilityId)
+        public async Task SetWorkingHours(List<WorkingHourDTO> workingHours, int facilityId)
         {
             if (workingHours.Any(w => w.TimeFrom >= w.TimeTo))
                 throw new ValidationException("pages.working-hours.errors.TIMES_NOT_IN_ORDER");
@@ -63,7 +66,9 @@ namespace Appy.Services
             context.WorkingHours.RemoveRange(context.WorkingHours.Where(w => w.FacilityId == facilityId));
 
             context.WorkingHours.AddRange(entites);
-            return context.SaveChangesAsync();
+            await context.SaveChangesAsync();
+
+            logger.LogInformation("Working hours replaced for facilityId {FacilityId}: {Count} entries", facilityId, workingHours.Count);
         }
     }
 }

--- a/Appy/Services/WorkingHourService.cs
+++ b/Appy/Services/WorkingHourService.cs
@@ -2,7 +2,6 @@
 using Appy.DTOs;
 using Appy.Exceptions;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 
 namespace Appy.Services
 {

--- a/Appy/appsettings.Development.json
+++ b/Appy/appsettings.Development.json
@@ -2,7 +2,9 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore": "Warning",
+      "Appy": "Debug"
     }
   }
 }

--- a/Appy/appsettings.json
+++ b/Appy/appsettings.json
@@ -2,7 +2,9 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore": "Warning",
+      "Appy": "Information"
     }
   },
   "AllowedHosts": "*",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ npx cypress run      # Headless E2E
 | JWT Authentication | `Appy/Auth/CLAUDE.md` |
 | Exception System | `Appy/Exceptions/CLAUDE.md` |
 | Backend Utilities | `Appy/Utils/CLAUDE.md` |
+| Request Middleware | `Appy/Middleware/CLAUDE.md` |
 | Frontend Domain Models | `Appy/Appy-frontend/src/app/models/CLAUDE.md` |
 | Global App Services | `Appy/Appy-frontend/src/app/services/CLAUDE.md` |
 | Shared (Services, Pipes, Directives) | `Appy/Appy-frontend/src/app/shared/CLAUDE.md` |


### PR DESCRIPTION
Closes #87.

## What & why
Issue #87: notification send failures were silently swallowed in `ClientNotificationsService` — no way to tell which client/contact/appointment failed or why. This fixes that and, per the expanded scope, adds correct, correlated logging across the whole backend using the built-in `Microsoft.Extensions.Logging` (no new dependencies).

## Changes
- **Config (`Program.cs` + appsettings):** clear providers; dev → readable single-line console + Debug, prod → JSON console; `IncludeScopes` on; per-category levels (`Microsoft.EntityFrameworkCore` pinned to Warning to kill per-SQL noise; `Appy` Information in prod / Debug in dev).
- **`RequestLoggingMiddleware` (new):** logs each request's method/path/status/elapsed and opens a `RequestId` correlation scope. `JwtMiddleware`/`FacilityMiddleware` add nested `UserId`/`FacilityId` scopes — downstream logs inherit them.
- **`ExceptionMiddleware` rework:** structured templates; logs `HttpException` by severity (4xx → Information, 5xx → Error); **now also catches unhandled exceptions** → logs at Error and returns a generic 500 (no stack-trace leak). HttpException response body/status unchanged.
- **#87 — `ClientNotificationsService`:** per-contact Debug breadcrumbs (with skip reason + contact type), Information on success, and a **Warning with client id + contact types tried before throwing `MESSAGE_FAILED_TO_SEND`**. Send control flow unchanged.
- **Service layer:** Information on significant mutations (appointments, services, clients, working hours, facilities, dashboard); auth events + **refresh-token-reuse Warning** in `UserService`; full-exception logging in the reminder cron + a per-run summary.
- **Docs:** updated pipeline, a Logging conventions section, and the new `Middleware/` folder in the relevant `CLAUDE.md` files.

## Conventions
Debug = diagnostic detail · Information = significant business events · Warning = handled failures + security signals · Error = unexpected/5xx. Always message templates; correlation ids come from scopes (not repeated in messages).

## Verification
- `dotnet build`: 0 errors
- Unit tests: **38/38** (new tests for RequestLoggingMiddleware, ExceptionMiddleware, and the #87 send-failure Warning)
- Manual runtime check: confirmed correlated request/business logs in the live backend
- Cypress E2E: **35/35** passing (logging is behavior-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)