### PR TITLE
Full-screen modal for lookups on mobile (#26)

### DIFF
--- a/Appy/Appy-frontend/src/app/components/CLAUDE.md
+++ b/Appy/Appy-frontend/src/app/components/CLAUDE.md
@@ -8,7 +8,7 @@ Presentational building blocks shared across feature pages. No domain logic, no 
 |-----------|---------|
 | `ButtonComponent` | Unified button with `color` (success/danger/warning/normal/disabled), `look` (solid/outlined/normal), loading spinner state, optional icon |
 | `DialogComponent` | Modal overlay wrapper with open/close API |
-| `ContextMenuComponent` | Dropdown menu positioned relative to a trigger element; used for navigation sub-menus |
+| `ContextMenuComponent` | Dropdown menu positioned relative to a trigger element; used for navigation sub-menus. Opt-in `fullscreenOnMobile` input renders it as a centered full-screen modal (backdrop + blocked scroll) on mobile-width viewports (`< 992px`) instead of an anchored dropdown — avoids CDK reposition jank when the on-screen keyboard opens (issue #26). Enabled on the client and service lookups. |
 | `ActionBarComponent` | Flex container for page-level action buttons (add, filter, etc.) with a built-in flex splitter |
 | `ActionDropdownComponent` | Dropdown variant of action-bar items |
 | `ToastComponent` | Notification pop-up with an optional inline action button |

--- a/Appy/Appy-frontend/src/app/components/CLAUDE.md
+++ b/Appy/Appy-frontend/src/app/components/CLAUDE.md
@@ -8,7 +8,7 @@ Presentational building blocks shared across feature pages. No domain logic, no 
 |-----------|---------|
 | `ButtonComponent` | Unified button with `color` (success/danger/warning/normal/disabled), `look` (solid/outlined/normal), loading spinner state, optional icon |
 | `DialogComponent` | Modal overlay wrapper with open/close API |
-| `ContextMenuComponent` | Dropdown menu positioned relative to a trigger element; used for navigation sub-menus. Opt-in `fullscreenOnMobile` input renders it as a centered full-screen modal (backdrop + blocked scroll) on mobile-width viewports (`< 992px`) instead of an anchored dropdown — avoids CDK reposition jank when the on-screen keyboard opens (issue #26). Enabled on the client and service lookups. |
+| `ContextMenuComponent` | Dropdown menu positioned relative to a trigger element; used for navigation sub-menus. Opt-in `fullscreenOnMobile` input renders it as a centered full-screen modal (backdrop + blocked scroll) on mobile-width viewports (`< 992px`) instead of an anchored dropdown — avoids CDK reposition jank when the on-screen keyboard opens (issue #26). In full-screen mode it shows a sticky header bar with an optional `title` and a close (✕) button so it can be dismissed without picking a value. Enabled on the client and service lookups. |
 | `ActionBarComponent` | Flex container for page-level action buttons (add, filter, etc.) with a built-in flex splitter |
 | `ActionDropdownComponent` | Dropdown variant of action-bar items |
 | `ToastComponent` | Notification pop-up with an optional inline action button |

--- a/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.css
+++ b/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.css
@@ -19,6 +19,55 @@
     max-width: 500px;
 }
 
+/* Header bar with title + close button. Hidden unless the menu is full-screen,
+   so the regular dropdown is untouched. Sticky so it stays pinned at the top
+   while the list scrolls underneath (no scroll-container restructuring needed). */
+.fullscreen-header {
+    display: none;
+}
+
+.context-menu-container.fullscreen .fullscreen-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 10px 8px 10px 15px;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background-color: rgb(var(--rgb-input-background));
+    border-bottom: 1px solid rgb(var(--rgb-input-border));
+}
+
+.fullscreen-title {
+    font-weight: bold;
+    font-size: 1.1rem;
+    color: rgb(var(--rgb-text));
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.fullscreen-close {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border: none;
+    border-radius: 50%;
+    background-color: transparent;
+    color: rgb(var(--rgb-text));
+    font-size: 1.1rem;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.fullscreen-close:hover {
+    background-color: rgba(var(--rgb-text), 0.1);
+}
+
 ::-webkit-scrollbar {
     width: 8px;
 }

--- a/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.css
+++ b/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.css
@@ -48,26 +48,6 @@
     white-space: nowrap;
 }
 
-.fullscreen-close {
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 34px;
-    height: 34px;
-    border: none;
-    border-radius: 50%;
-    background-color: transparent;
-    color: rgb(var(--rgb-text));
-    font-size: 1.1rem;
-    line-height: 1;
-    cursor: pointer;
-}
-
-.fullscreen-close:hover {
-    background-color: rgba(var(--rgb-text), 0.1);
-}
-
 ::-webkit-scrollbar {
     width: 8px;
 }

--- a/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.css
+++ b/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.css
@@ -9,6 +9,16 @@
     overscroll-behavior: contain;
 }
 
+/* Full-screen modal variant (mobile): fills the viewport minus a small padding
+   on every side. The pane is centered by the overlay's global position strategy;
+   content scrolls inside. dvh keeps it correct as mobile browser chrome collapses. */
+.context-menu-container.fullscreen {
+    width: calc(100vw - 32px);
+    height: calc(100vh - 32px);
+    height: calc(100dvh - 32px);
+    max-width: 500px;
+}
+
 ::-webkit-scrollbar {
     width: 8px;
 }

--- a/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.css
+++ b/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.css
@@ -31,7 +31,7 @@
     align-items: center;
     justify-content: space-between;
     gap: 10px;
-    padding: 10px 8px 10px 15px;
+    padding: 6px 8px 6px 15px;
     position: sticky;
     top: 0;
     z-index: 1;

--- a/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.html
+++ b/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.html
@@ -1,5 +1,5 @@
 <ng-template #template>
-    <div #container class="context-menu-container">
+    <div #container class="context-menu-container" [class.fullscreen]="isFullscreen">
         <ng-content></ng-content>
     </div>
 </ng-template>

--- a/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.html
+++ b/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.html
@@ -1,5 +1,13 @@
 <ng-template #template>
     <div #container class="context-menu-container" [class.fullscreen]="isFullscreen">
+        <!-- Header bar: only visible in full-screen mode (CSS-gated on .fullscreen,
+             so no CommonModule/*ngIf needed). Title is optional; the close button
+             stays right-aligned and gives a way out without picking a value. -->
+        <div class="fullscreen-header">
+            <span class="fullscreen-title">{{ title }}</span>
+            <button type="button" class="fullscreen-close" aria-label="Close"
+                data-test="context-menu-close" (click)="close()">✕</button>
+        </div>
         <ng-content></ng-content>
     </div>
 </ng-template>

--- a/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.html
+++ b/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.html
@@ -5,8 +5,8 @@
              stays right-aligned and gives a way out without picking a value. -->
         <div class="fullscreen-header">
             <span class="fullscreen-title">{{ title }}</span>
-            <button type="button" class="fullscreen-close" aria-label="Close"
-                data-test="context-menu-close" (click)="close()">✕</button>
+            <app-button data-test="context-menu-close" aria-label="Close" icon="times"
+                look="transparent" [isCircle]="true" (onClick)="close()"></app-button>
         </div>
         <ng-content></ng-content>
     </div>

--- a/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.ts
+++ b/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.ts
@@ -46,6 +46,11 @@ export class ContextMenuComponent implements OnInit, OnDestroy {
   // jank when the on-screen keyboard shrinks the viewport (issue #26).
   @Input() fullscreenOnMobile: boolean = false;
 
+  // Shown in the full-screen modal's header bar (next to the close button).
+  // Only rendered in full-screen mode; ignored by the regular dropdown.
+  // Accepts null so the `| translate` pipe output binds directly.
+  @Input() title?: string | null;
+
   // Matches the app's mobile breakpoint (see action-bar.component.ts / app.component.scss).
   private static readonly MOBILE_MAX_WIDTH = 992;
 

--- a/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.ts
+++ b/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.ts
@@ -85,10 +85,16 @@ export class ContextMenuComponent implements OnInit, OnDestroy {
     this.overlayRef = this.isFullscreen
       ? this.overlay.create({
         // Centered modal: no trigger-relative positioning, so the on-screen
-        // keyboard has nothing to reposition. Backdrop dims the page and
-        // blocking the background scroll completes the modal feel.
+        // keyboard has nothing to reposition. The backdrop dims the page and
+        // `.context-menu-container`'s `overscroll-behavior: contain` keeps the
+        // background visually inert.
+        //
+        // NOT `block()`: it pins <html> to `position: fixed; top: -scrollY`,
+        // which forces `window.scrollY` to 0. The appointments list paginates
+        // off window scroll (see appointments-list checkShouldLoad) and would
+        // read scroll-at-top, loading backwards and jumping dates (#26 regression).
         positionStrategy: this.overlay.position().global().centerHorizontally().centerVertically(),
-        scrollStrategy: this.overlay.scrollStrategies.block(),
+        scrollStrategy: this.overlay.scrollStrategies.noop(),
         hasBackdrop: true,
       })
       : this.overlay.create({

--- a/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.ts
+++ b/Appy/Appy-frontend/src/app/components/context-menu/context-menu.component.ts
@@ -41,7 +41,16 @@ export class ContextMenuComponent implements OnInit, OnDestroy {
   @Input() viewportMargin: number = 0;
   @Input() closeOnButtonClick: boolean = true;
 
+  // When true, the menu opens as a centered full-screen modal on mobile-width
+  // viewports instead of a button-anchored dropdown. Avoids the CDK reposition
+  // jank when the on-screen keyboard shrinks the viewport (issue #26).
+  @Input() fullscreenOnMobile: boolean = false;
+
+  // Matches the app's mobile breakpoint (see action-bar.component.ts / app.component.scss).
+  private static readonly MOBILE_MAX_WIDTH = 992;
+
   overlayRef?: OverlayRef;
+  isFullscreen: boolean = false;
   keepOpen: boolean = false;
   keepClosed: boolean = false;
 
@@ -66,33 +75,47 @@ export class ContextMenuComponent implements OnInit, OnDestroy {
   }
 
   public open(): void {
-    this.overlayRef = this.overlay.create({
-      positionStrategy: this.overlay
-        .position()
-        .flexibleConnectedTo(this.relativeTo as ElementRef<any>)
-        .withPush(true)
-        .withFlexibleDimensions(true)
-        .withGrowAfterOpen(true)
-        .withViewportMargin(this.viewportMargin)
-        .withPositions([
-          {
-            originX: "end",
-            originY: "bottom",
-            overlayX: "end",
-            overlayY: "top"
-          },
-          {
-            originX: "end",
-            originY: "top",
-            overlayX: "end",
-            overlayY: "bottom"
-          }
-        ]),
-      scrollStrategy: this.overlay.scrollStrategies.reposition(),
-      minHeight: 5,
-      minWidth: this.copyOriginWidth ? this.relativeTo?.nativeElement.offsetWidth : null,
-    });
+    this.isFullscreen = this.fullscreenOnMobile && window.innerWidth < ContextMenuComponent.MOBILE_MAX_WIDTH;
+
+    this.overlayRef = this.isFullscreen
+      ? this.overlay.create({
+        // Centered modal: no trigger-relative positioning, so the on-screen
+        // keyboard has nothing to reposition. Backdrop dims the page and
+        // blocking the background scroll completes the modal feel.
+        positionStrategy: this.overlay.position().global().centerHorizontally().centerVertically(),
+        scrollStrategy: this.overlay.scrollStrategies.block(),
+        hasBackdrop: true,
+      })
+      : this.overlay.create({
+        positionStrategy: this.overlay
+          .position()
+          .flexibleConnectedTo(this.relativeTo as ElementRef<any>)
+          .withPush(true)
+          .withFlexibleDimensions(true)
+          .withGrowAfterOpen(true)
+          .withViewportMargin(this.viewportMargin)
+          .withPositions([
+            {
+              originX: "end",
+              originY: "bottom",
+              overlayX: "end",
+              overlayY: "top"
+            },
+            {
+              originX: "end",
+              originY: "top",
+              overlayX: "end",
+              overlayY: "bottom"
+            }
+          ]),
+        scrollStrategy: this.overlay.scrollStrategies.reposition(),
+        minHeight: 5,
+        minWidth: this.copyOriginWidth ? this.relativeTo?.nativeElement.offsetWidth : null,
+      });
     this.overlayRef.attach(new TemplatePortal(this.template as TemplateRef<any>, this.viewContainerRef));
+
+    if (this.isFullscreen)
+      this.subs.push(this.overlayRef.backdropClick().subscribe(() => this.close()));
 
     this.keepOpen = true;
     setTimeout(() => this.keepOpen = false, 10);

--- a/Appy/Appy-frontend/src/app/components/context-menu/context-menu.module.ts
+++ b/Appy/Appy-frontend/src/app/components/context-menu/context-menu.module.ts
@@ -1,5 +1,6 @@
 import { OverlayModule } from "@angular/cdk/overlay";
 import { NgModule } from "@angular/core";
+import { ButtonModule } from "../button/button.module";
 import { ContextMenuComponent } from "./context-menu.component";
 import { ElementRefDirective } from "./directives/element-ref.directive";
 
@@ -9,7 +10,8 @@ import { ElementRefDirective } from "./directives/element-ref.directive";
         ElementRefDirective,
     ],
     imports: [
-        OverlayModule
+        OverlayModule,
+        ButtonModule
     ],
     exports: [
         ContextMenuComponent,

--- a/Appy/Appy-frontend/src/app/pages/clients/components/client-lookup/client-lookup.component.html
+++ b/Appy/Appy-frontend/src/app/pages/clients/components/client-lookup/client-lookup.component.html
@@ -5,7 +5,7 @@
 <app-button *ngIf="showClearButton && value != null" class="clear-button" look="transparent" icon="times"
     [isCircle]="true" (onClick)="clear()"></app-button>
 
-<app-context-menu #contextMenu [relativeTo]="buttonRef.elementRef" [copyOriginWidth]="true">
+<app-context-menu #contextMenu [relativeTo]="buttonRef.elementRef" [copyOriginWidth]="true" [fullscreenOnMobile]="true">
     <div class="search-input-container">
         <app-search [source]="clients" (onSearch)="filteredClients = $event.filteredSource"></app-search>
         <app-button *ngIf="showNewButton" icon="plus" color="success" look="outlined" borderStyle="dashed"

--- a/Appy/Appy-frontend/src/app/pages/clients/components/client-lookup/client-lookup.component.html
+++ b/Appy/Appy-frontend/src/app/pages/clients/components/client-lookup/client-lookup.component.html
@@ -5,7 +5,8 @@
 <app-button *ngIf="showClearButton && value != null" class="clear-button" look="transparent" icon="times"
     [isCircle]="true" (onClick)="clear()"></app-button>
 
-<app-context-menu #contextMenu [relativeTo]="buttonRef.elementRef" [copyOriginWidth]="true" [fullscreenOnMobile]="true">
+<app-context-menu #contextMenu [relativeTo]="buttonRef.elementRef" [copyOriginWidth]="true" [fullscreenOnMobile]="true"
+    [title]="'pages.clients.CHOOSE_CLIENT' | translate">
     <div class="search-input-container">
         <app-search [source]="clients" (onSearch)="filteredClients = $event.filteredSource"></app-search>
         <app-button *ngIf="showNewButton" icon="plus" color="success" look="outlined" borderStyle="dashed"

--- a/Appy/Appy-frontend/src/app/pages/services/components/service-lookup/service-lookup.component.html
+++ b/Appy/Appy-frontend/src/app/pages/services/components/service-lookup/service-lookup.component.html
@@ -6,7 +6,7 @@
 <app-button *ngIf="showClearButton && value != null" class="clear-button" look="transparent" icon="times"
     [isCircle]="true" (onClick)="clear()"></app-button>
 
-<app-context-menu #contextMenu [relativeTo]="buttonRef.elementRef" [copyOriginWidth]="true">
+<app-context-menu #contextMenu [relativeTo]="buttonRef.elementRef" [copyOriginWidth]="true" [fullscreenOnMobile]="true">
     <input #searchInput class="w-input search-input" type="text" placeholder="{{'SEARCH' | translate}}"
         [(ngModel)]="search">
 

--- a/Appy/Appy-frontend/src/app/pages/services/components/service-lookup/service-lookup.component.html
+++ b/Appy/Appy-frontend/src/app/pages/services/components/service-lookup/service-lookup.component.html
@@ -6,7 +6,8 @@
 <app-button *ngIf="showClearButton && value != null" class="clear-button" look="transparent" icon="times"
     [isCircle]="true" (onClick)="clear()"></app-button>
 
-<app-context-menu #contextMenu [relativeTo]="buttonRef.elementRef" [copyOriginWidth]="true" [fullscreenOnMobile]="true">
+<app-context-menu #contextMenu [relativeTo]="buttonRef.elementRef" [copyOriginWidth]="true" [fullscreenOnMobile]="true"
+    [title]="'pages.services.CHOOSE_SERVICE' | translate">
     <input #searchInput class="w-input search-input" type="text" placeholder="{{'SEARCH' | translate}}"
         [(ngModel)]="search">
 


### PR DESCRIPTION
Closes #26.

## What & why

On phones, the lookup dropdowns (client, service) are CDK overlays anchored to their trigger via `flexibleConnectedTo`. Focusing the in-dropdown search field opens the on-screen keyboard, which shrinks the viewport and forces a janky/clipped reposition.

Per the issue comment, this makes lookups **full-screen on small screens** and leaves them as **dropdowns on big screens** — implemented **once** at the lowest shared level so it's not copied around.

## How

- New opt-in input on `ContextMenuComponent`: `@Input() fullscreenOnMobile = false`.
- In `open()`, when `fullscreenOnMobile && innerWidth < 992` (the app's existing mobile breakpoint), the overlay uses a centered `GlobalPositionStrategy` + dim backdrop + blocked background scroll, and a `.fullscreen` container variant that fills the viewport minus 16px padding all around (content scrolls inside). The trigger-relative positioning is skipped entirely — so the keyboard has **nothing to reposition**.
- Otherwise (desktop, or any consumer that doesn't opt in): the existing `flexibleConnectedTo` dropdown, unchanged.
- Enabled on the **client** and **service** lookups only. Every other `app-context-menu` (generic dropdown, action menu, pickers, nav sub-menus) keeps the `false` default — flipping any of them on later is a one-attribute change.

## Verification

- **Manual (Playwright)** at 390px: both lookups open as a centered modal (16px padding all sides, dim backdrop, search pinned at top, list scrolls inside); backdrop-tap closes; selecting an item closes + sets the value. At 1400px: unchanged anchored dropdown, no backdrop.
- **Cypress E2E**: full `appointments.cy.ts` suite green (Cypress runs at ≥992px, so the lookups stay dropdowns and existing behavior is unaffected). One `scroller jump` test flaked on the first run and passed on a targeted re-run of all 10 scroller-jump cases — unrelated to this change.