### PR TITLE
fix: UpcomingUnconfirmed dashboard endpoint returns bare appointment list (#145)

### DIFF
--- a/Appy.Tests/CLAUDE.md
+++ b/Appy.Tests/CLAUDE.md
@@ -4,7 +4,11 @@ xUnit unit tests for backend service logic. Targets **.NET 8.0**, same as the ma
 
 ## What Is Tested
 
-Tests live in `Services/` and `Utils/`. The `Services/` tests cover four services:
+Tests live in `Services/`, `Utils/`, `Middleware/`, `Exceptions/`, and `Controllers/`.
+
+- **DashboardControllerTests** (`Controllers/`): verifies `UpcomingUnconfirmed` unwraps the `AppointmentListPageDTO` envelope from `IAppointmentService.GetList` and returns the bare `List<AppointmentViewDTO>` the frontend expects (not the whole page with its `TimeOffs`).
+
+The `Services/` tests cover four services:
 
 - **TrimmingStringConverterTests** (`Utils/`): verifies the global request-body string-trimming converter — leading/trailing whitespace is trimmed across top-level, nested, and collection string properties; `null` is preserved; whitespace-only becomes empty; and serialization (Write) is a passthrough that does not trim.
 

--- a/Appy.Tests/Controllers/DashboardControllerTests.cs
+++ b/Appy.Tests/Controllers/DashboardControllerTests.cs
@@ -1,0 +1,47 @@
+using Appy.Controllers;
+using Appy.DTOs;
+using Appy.Services;
+using Appy.Services.SmartFiltering;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace Appy.Tests.Controllers
+{
+    public class DashboardControllerTests
+    {
+        private const int FacilityId = 1;
+
+        private readonly Mock<IDashboardService> dashboardServiceMock = new();
+        private readonly Mock<IAppointmentService> appointmentServiceMock = new();
+        private readonly DashboardController controller;
+
+        public DashboardControllerTests()
+        {
+            controller = new DashboardController(dashboardServiceMock.Object, appointmentServiceMock.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["facilityId"] = FacilityId;
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task UpcomingUnconfirmed_ReturnsBareAppointmentList_NotThePageEnvelope()
+        {
+            var appointments = new List<AppointmentViewDTO> { new() { Id = 1 }, new() { Id = 2 } };
+
+            appointmentServiceMock
+                .Setup(x => x.GetList(It.IsAny<DateOnly>(), It.IsAny<Direction>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<SmartFilter?>(), FacilityId))
+                .ReturnsAsync(new AppointmentListPageDTO
+                {
+                    Appointments = appointments,
+                    TimeOffs = new List<TimeOffOccurrenceDTO> { new() }
+                });
+
+            var result = await controller.UpcomingUnconfirmed(7);
+
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Same(appointments, ok.Value);
+        }
+    }
+}

--- a/Appy/Controllers/DashboardController.cs
+++ b/Appy/Controllers/DashboardController.cs
@@ -49,7 +49,7 @@ namespace Appy.Controllers
 
         [HttpGet("upcomingUnconfirmed")]
         [Authorize]
-        public async Task<ActionResult<List<AppointmentEditDTO>>> UpcomingUnconfirmed([FromQuery] int numberOfDays)
+        public async Task<ActionResult<List<AppointmentViewDTO>>> UpcomingUnconfirmed([FromQuery] int numberOfDays)
         {
             var endingDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(numberOfDays)).ToString("yyyy-MM-dd");
 
@@ -58,9 +58,9 @@ namespace Appy.Controllers
                 SmartFilter.FromFieldFilter(nameof(Appointment.Date), Comparator.LessThanOrEqual, endingDate)
             );
 
-            var appointments = await appointmentService.GetList(DateOnly.FromDateTime(DateTime.UtcNow), Direction.Forwards, 0, 100, filter, HttpContext.SelectedFacility());
+            var page = await appointmentService.GetList(DateOnly.FromDateTime(DateTime.UtcNow), Direction.Forwards, 0, 100, filter, HttpContext.SelectedFacility());
 
-            return Ok(appointments);
+            return Ok(page.Appointments);
         }
     }
 }


### PR DESCRIPTION
## Problem

The dashboard **Upcoming Unconfirmed** widget crashed with `Pe.map is not a function`.

`AppointmentService.GetList` returns an envelope `AppointmentListPageDTO { Appointments, TimeOffs }` (introduced with Time-off management, #140), but `DashboardController.UpcomingUnconfirmed` returned that envelope raw. The frontend (`DashboardService.getUpcomingUnconfirmed`) does `aps.map(...)`, expecting a bare array — so it threw on the object.

## Fix

Return `page.Appointments` from the endpoint and correct the declared response type to `List<AppointmentViewDTO>`. The dashboard widget only needs the appointments, not the page's `TimeOffs`.

## Verification

- **New unit test** `DashboardControllerTests.UpcomingUnconfirmed_ReturnsBareAppointmentList_NotThePageEnvelope` — fails before the fix, passes after.
- **Full backend suite**: 111/111 pass.
- **Manual (Playwright, seeded DB)**: dashboard widget renders with zero console errors; `GET /dashboard/upcomingUnconfirmed` returns `200` + a bare JSON array (no envelope shape).

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)