### PR TITLE
fix: keep unsaved appointment edits when returning to the edit form (#58)

### DIFF
--- a/Appy/Appy-frontend/cypress/e2e/appointments.cy.ts
+++ b/Appy/Appy-frontend/cypress/e2e/appointments.cy.ts
@@ -1,4 +1,4 @@
-import { login } from "cypress/support/commands"
+import { expectURL, login } from "cypress/support/commands"
 import dayjs, { Dayjs } from 'dayjs';
 import { parseDuration } from "src/app/utils/time-utils";
 import duration from "dayjs/plugin/duration";
@@ -278,6 +278,52 @@ describe('Appointments', () => {
     { name: "client changes", revertsStatus: true, edit: () => appointmentEdit.getClientLookup().select("Client2") },
     { name: "only duration changes", revertsStatus: false, edit: () => appointmentEdit.getDurationLookup().select("00:45") },
   ];
+
+  // --- Unsaved edits survive leaving the form and coming back ---
+  // Adding a client mid-booking and then opening that client's page takes the user off the edit
+  // form; the browser Back button must bring every in-progress edit back with them.
+  it("Should keep unsaved edits when leaving the edit form to a client's page and coming back", () => {
+    let appointment = {
+      client: "Client1",
+      service: getTestService("Service1"),
+      date: dayjs("2025-11-10"),
+      time: "09:00",
+      duration: "00:30"
+    };
+
+    let newDate = dayjs("2025-11-17");
+    let newTime = "13:00";
+    let newDuration = "00:45";
+    let newClient = "Newcomer Person";
+    let newNotes = "brings her own shampoo";
+
+    appointments.openScrollerView();
+    appointments.getCurrentDate().then(currentDate => {
+      appointments.plusButton();
+      editAndSaveAppointment(appointment, undefined, currentDate);
+    });
+
+    expectAppointment(appointment).then(item => {
+      appointments.list().viewAppointment(item.id);
+      appointmentView.edit();
+
+      appointmentEdit.getDateTimeLookup().open().select(newDate, newTime);
+      appointmentEdit.getDurationLookup().select(newDuration);
+      appointmentEdit.getNotes().type(newNotes);
+      appointmentEdit.getClientLookup().addNew(newClient);
+
+      toast.expectVisible().expectAction("pen").clickAction("pen");
+      expectURL(/\/clients\/edit\/\d+/);
+
+      cy.go("back");
+
+      appointmentEdit.getDateTimeLookup().expectSelected(newDate, newTime);
+      appointmentEdit.getDurationLookup().expectSelected(newDuration);
+      appointmentEdit.getClientLookup().expectSelected(newClient.split(" ")[0]);
+      appointmentEdit.getServiceLookup().expectSelected(appointment.service.displayName);
+      appointmentEdit.getNotes().expectText(newNotes);
+    });
+  });
 
   for (let option of statusRevertOptions) {
     it(`Should ${option.revertsStatus ? "revert Confirmed to Unconfirmed" : "keep Confirmed status"} when ${option.name}`, () => {

--- a/Appy/Appy-frontend/cypress/e2e/lookups/client-lookup.ts
+++ b/Appy/Appy-frontend/cypress/e2e/lookups/client-lookup.ts
@@ -31,5 +31,17 @@ export function clientLookup(elementSelector: string) {
 
       return this;
     },
+
+    // Creates the client from the popup's search text, the way a user adds someone mid-booking.
+    // The new client is selected on success and the popup closes on its own.
+    addNew(nameSurname: string) {
+      getElement(elementSelector).click();
+      getElement("client-lookup-search").find("input").type(nameSurname);
+      getElement("client-lookup-new-button").click();
+
+      this.expectSelected(nameSurname.split(" ")[0]);
+
+      return this;
+    },
   };
 }

--- a/Appy/Appy-frontend/cypress/e2e/pages/appointments.ts
+++ b/Appy/Appy-frontend/cypress/e2e/pages/appointments.ts
@@ -260,6 +260,24 @@ export let appointmentEdit = {
     return durationLookup("appointment-edit-duration-picker");
   },
 
+  getNotes() {
+    this.checkView();
+
+    return {
+      type(notes: string) {
+        getElement("appointment-edit-notes-input").clear().type(notes);
+
+        return this;
+      },
+
+      expectText(notes: string) {
+        getElement("appointment-edit-notes-input").should("have.value", notes);
+
+        return this;
+      }
+    };
+  },
+
   getDateTimeLookup() {
     this.checkView();
 

--- a/Appy/Appy-frontend/src/app/pages/appointments/components/appointment-edit/appointment-edit.component.spec.ts
+++ b/Appy/Appy-frontend/src/app/pages/appointments/components/appointment-edit/appointment-edit.component.spec.ts
@@ -1,0 +1,139 @@
+import { fakeAsync, tick } from "@angular/core/testing";
+import { convertToParamMap } from "@angular/router";
+import dayjs from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
+import durationPlugin from "dayjs/plugin/duration";
+import { of } from "rxjs";
+import { Appointment } from "src/app/models/appointment";
+import { ClientDTO } from "src/app/models/client";
+import { ServiceDTO } from "src/app/models/service";
+import { AppointmentEditComponent } from "./appointment-edit.component";
+
+// The Appointment model parses dates and durations on construction and on every property set.
+dayjs.extend(customParseFormat);
+dayjs.extend(durationPlugin);
+
+function service(id: number, duration: string): ServiceDTO {
+  return { id, name: `Service${id}`, displayName: `Service${id}`, duration };
+}
+
+function client(id: number): ClientDTO {
+  return { id, name: `Client${id}` };
+}
+
+function savedAppointment(): Appointment {
+  return new Appointment({
+    id: 7,
+    date: "2026-03-01",
+    time: "10:00:00",
+    duration: "01:00:00",
+    service: service(1, "01:00:00"),
+    client: client(1),
+    notes: "as saved"
+  });
+}
+
+// ngOnInit is the subject: it combines route data, params and query params behind a debounce,
+// so every case drives it inside fakeAsync and ticks the debounce out.
+function init(opts: { isNew?: boolean, id?: string, queryParams?: { [key: string]: string }, loaded?: Appointment }): AppointmentEditComponent {
+  const appointmentService = { get: () => of(opts.loaded) };
+  const route = {
+    data: of(opts.isNew ? { isNew: true } : {}),
+    paramMap: of(convertToParamMap(opts.id != null ? { id: opts.id } : {})),
+    queryParamMap: of(convertToParamMap(opts.queryParams ?? {}))
+  };
+
+  const c = new AppointmentEditComponent(
+    null as any, null as any, route as any, appointmentService as any, null as any, null as any, null as any);
+
+  c.ngOnInit();
+  tick();
+
+  return c;
+}
+
+describe("AppointmentEditComponent — unsaved edits carried in the URL", () => {
+  it("applies every edited field from the URL over the saved appointment", fakeAsync(() => {
+    const c = init({
+      id: "7",
+      loaded: savedAppointment(),
+      queryParams: {
+        date: "2026-03-05",
+        time: "14:30:00",
+        duration: "00:45:00",
+        service: JSON.stringify(service(2, "00:30:00")),
+        client: JSON.stringify(client(2)),
+        notes: "edited"
+      }
+    });
+
+    expect(c.appointment!.date!.format("YYYY-MM-DD")).toBe("2026-03-05");
+    expect(c.appointment!.time!.format("HH:mm:ss")).toBe("14:30:00");
+    expect(c.appointment!.duration!.format("HH:mm:ss")).toBe("00:45:00");
+    expect(c.appointment!.service!.id).toBe(2);
+    expect(c.appointment!.client!.id).toBe(2);
+    expect(c.appointment!.notes).toBe("edited");
+    expect(c.appointment!.id).toBe(7);
+  }));
+
+  it("keeps the saved values of the fields the URL does not carry", fakeAsync(() => {
+    const c = init({ id: "7", loaded: savedAppointment(), queryParams: { date: "2026-03-05" } });
+
+    expect(c.appointment!.date!.format("YYYY-MM-DD")).toBe("2026-03-05");
+    expect(c.appointment!.time!.format("HH:mm:ss")).toBe("10:00:00");
+    expect(c.appointment!.duration!.format("HH:mm:ss")).toBe("01:00:00");
+    expect(c.appointment!.service!.id).toBe(1);
+    expect(c.appointment!.client!.id).toBe(1);
+    expect(c.appointment!.notes).toBe("as saved");
+  }));
+
+  it("shows the saved appointment untouched when the URL carries no edits", fakeAsync(() => {
+    const c = init({ id: "7", loaded: savedAppointment() });
+
+    expect(c.appointment!.date!.format("YYYY-MM-DD")).toBe("2026-03-01");
+    expect(c.appointment!.time!.format("HH:mm:ss")).toBe("10:00:00");
+    expect(c.appointment!.duration!.format("HH:mm:ss")).toBe("01:00:00");
+    expect(c.appointment!.service!.id).toBe(1);
+    expect(c.appointment!.client!.id).toBe(1);
+    expect(c.appointment!.notes).toBe("as saved");
+  }));
+
+  it("keeps a saved duration that differs from the URL service's own duration", fakeAsync(() => {
+    const c = init({
+      id: "7",
+      loaded: savedAppointment(),
+      queryParams: { service: JSON.stringify(service(2, "00:30:00")) }
+    });
+
+    expect(c.appointment!.service!.id).toBe(2);
+    expect(c.appointment!.duration!.format("HH:mm:ss")).toBe("01:00:00");
+  }));
+
+  it("seeds a new appointment from the URL params", fakeAsync(() => {
+    const c = init({
+      isNew: true,
+      queryParams: {
+        date: "2026-03-05",
+        time: "14:30:00",
+        duration: "00:45:00",
+        service: JSON.stringify(service(2, "00:30:00")),
+        client: JSON.stringify(client(2)),
+        notes: "edited"
+      }
+    });
+
+    expect(c.appointment!.id).toBe(0);
+    expect(c.appointment!.date!.format("YYYY-MM-DD")).toBe("2026-03-05");
+    expect(c.appointment!.time!.format("HH:mm:ss")).toBe("14:30:00");
+    expect(c.appointment!.duration!.format("HH:mm:ss")).toBe("00:45:00");
+    expect(c.appointment!.service!.id).toBe(2);
+    expect(c.appointment!.client!.id).toBe(2);
+    expect(c.appointment!.notes).toBe("edited");
+  }));
+
+  it("takes a new appointment's duration from its service when the URL carries none", fakeAsync(() => {
+    const c = init({ isNew: true, queryParams: { service: JSON.stringify(service(2, "00:30:00")) } });
+
+    expect(c.appointment!.duration!.format("HH:mm:ss")).toBe("00:30:00");
+  }));
+});

--- a/Appy/Appy-frontend/src/app/pages/appointments/components/appointment-edit/appointment-edit.component.ts
+++ b/Appy/Appy-frontend/src/app/pages/appointments/components/appointment-edit/appointment-edit.component.ts
@@ -14,6 +14,7 @@ import { TranslateService } from 'src/app/components/translate/translate.service
 import { ClientDTO } from 'src/app/models/client';
 import { ToastService } from 'src/app/components/toast/toast.service';
 import { IconName } from '@fortawesome/fontawesome-svg-core';
+import dayjs from 'dayjs';
 
 @Component({
   selector: 'app-appointment-edit',
@@ -46,42 +47,21 @@ export class AppointmentEditComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit(): void {
-    let queryParamMap = this.activatedRoute.snapshot.queryParamMap;
-
     this.subs.push(combineLatest([this.activatedRoute.data, this.activatedRoute.paramMap, this.activatedRoute.queryParamMap])
       .pipe(debounceTime(0)).subscribe(([data, paramMap, queryParamMap]: [Data, ParamMap, ParamMap]) => {
         this.isNew = data["isNew"] ?? false;
 
         if (this.isNew) {
-          let date = queryParamMap.get("date") ?? undefined;
-          let time = queryParamMap.get("time") ?? undefined;
-          let duration = queryParamMap.get("duration") ?? undefined;
+          let appointment = new Appointment();
+          this.applyUrlParams(appointment, queryParamMap);
 
-          let serviceJSON = queryParamMap.get("service");
-          let service: ServiceDTO | undefined;
-          if (serviceJSON != null)
-            service = JSON.parse(serviceJSON);
-
-          let clientJSON = queryParamMap.get("client");
-          let client: ClientDTO | undefined;
-          if (clientJSON != null)
-            client = JSON.parse(clientJSON);
-
-          this.appointment = new Appointment({
-            id: 0,
-            date: date,
-            time: time,
-            service: service,
-            client: client,
-            duration: duration ?? service?.duration
-          });
-
+          this.appointment = appointment;
           this.registerPropertyChanged();
         }
         else {
           var idParam = paramMap.get("id");
           if (idParam)
-            this.load(Number.parseInt(idParam));
+            this.load(Number.parseInt(idParam), queryParamMap);
         }
       }));
   }
@@ -90,11 +70,43 @@ export class AppointmentEditComponent implements OnInit, OnDestroy {
     this.subs.forEach(s => s.unsubscribe());
   }
 
-  private load(id: number) {
+  private load(id: number, queryParamMap: ParamMap) {
     this.subs.push(this.appointmentService.get(id).subscribe((a: Appointment) => {
+      this.applyUrlParams(a, queryParamMap);
+
       this.appointment = a;
       this.registerPropertyChanged();
     }));
+  }
+
+  // The URL holds the edits made before navigating away, so they take precedence over the
+  // saved appointment. Applied before registerPropertyChanged so restoring doesn't rewrite the URL.
+  private applyUrlParams(appointment: Appointment, queryParamMap: ParamMap) {
+    let date = queryParamMap.get("date");
+    if (date != null)
+      appointment.date = dayjs(date);
+
+    let time = queryParamMap.get("time");
+    if (time != null)
+      appointment.time = dayjs(time, "HH:mm:ss");
+
+    let serviceJSON = queryParamMap.get("service");
+    if (serviceJSON != null)
+      appointment.service = JSON.parse(serviceJSON) as ServiceDTO;
+
+    let clientJSON = queryParamMap.get("client");
+    if (clientJSON != null)
+      appointment.client = JSON.parse(clientJSON) as ClientDTO;
+
+    let notes = queryParamMap.get("notes");
+    if (notes != null)
+      appointment.notes = notes;
+
+    let duration = queryParamMap.get("duration");
+    if (duration != null)
+      appointment.duration = parseDuration(duration);
+    else if (appointment.duration == null && appointment.service?.duration != null)
+      appointment.duration = parseDuration(appointment.service.duration);
   }
 
   public cancel() {
@@ -187,9 +199,10 @@ export class AppointmentEditComponent implements OnInit, OnDestroy {
       let duration = this.appointment?.duration ? this.appointment.duration.format("HH:mm:ss") : null;
       let service = this.appointment?.service ? JSON.stringify(this.appointment.service) : null;
       let client = this.appointment?.client ? JSON.stringify(this.appointment.client) : null;
+      let notes = this.appointment?.notes ?? null;
 
       setUrlParams(this.router, this.activatedRoute, this.location, {
-        date, time, duration, service, client
+        date, time, duration, service, client, notes
       });
     }));
   }

--- a/Appy/Appy-frontend/src/app/pages/appointments/components/appointment-edit/date-time-chooser/date-time-chooser.component.ts
+++ b/Appy/Appy-frontend/src/app/pages/appointments/components/appointment-edit/date-time-chooser/date-time-chooser.component.ts
@@ -12,6 +12,10 @@ import { overlap, timeOnly } from 'src/app/utils/time-utils';
 import dayjs from "dayjs";
 import { Dayjs } from "dayjs";
 import { Duration } from "dayjs/plugin/duration";
+// Type-only: augments the Dayjs interface with isBetween(). The plugin is registered at runtime in
+// app.module.ts; this import is needed only so this file type-checks when compiled in isolation
+// (e.g. under `ng test`, where app.module isn't in the graph). It is NOT redundant.
+import "dayjs/plugin/isBetween";
 import { ContextMenuComponent } from 'src/app/components/context-menu/context-menu.component';
 import { TimeData } from './time-button/time-button.component';
 import { AppointmentService } from '../../../services/appointment.service';

--- a/Appy/Appy-frontend/src/app/pages/clients/components/client-lookup/client-lookup.component.html
+++ b/Appy/Appy-frontend/src/app/pages/clients/components/client-lookup/client-lookup.component.html
@@ -8,10 +8,11 @@
 <app-context-menu #contextMenu [relativeTo]="buttonRef.elementRef" [copyOriginWidth]="true" [fullscreenOnMobile]="true"
     [title]="'pages.clients.CHOOSE_CLIENT' | translate">
     <div class="search-input-container">
-        <app-search [source]="clients" (onSearch)="filteredClients = $event.filteredSource"></app-search>
-        <app-button *ngIf="showNewButton" icon="plus" color="success" look="outlined" borderStyle="dashed"
-            [isLoading]="isLoadingNew" [disabled]="isLoadingNew" text="{{'NEW' | translate}}"
-            (onClick)="addNew()"></app-button>
+        <app-search data-test="client-lookup-search" [source]="clients"
+            (onSearch)="filteredClients = $event.filteredSource"></app-search>
+        <app-button data-test="client-lookup-new-button" *ngIf="showNewButton" icon="plus" color="success"
+            look="outlined" borderStyle="dashed" [isLoading]="isLoadingNew" [disabled]="isLoadingNew"
+            text="{{'NEW' | translate}}" (onClick)="addNew()"></app-button>
     </div>
     <div class="w-validation-message validation-error">{{ validationError | translate }}</div>
 


### PR DESCRIPTION
Fixes #58.

## The bug

1. Open an appointment for editing, change a field (e.g. the date)
2. Open the client lookup and create a new client from it
3. Press **Edit** on the success toast, then go back
4. Every changed field is back to its saved value

## Root cause

The editor keeps in-progress edits in the URL query params, so they survive the component being destroyed. Only the *new*-appointment branch of `ngOnInit` ever read those params back — the edit branch reloaded the appointment from the server and discarded them.

## The fix

Both branches now run the appointment through one shared `applyUrlParams`, so the URL wins over the saved values wherever it carries something. `notes` joins the params the form writes: it was the one editable field the URL never carried, so it was lost on the same round trip.

## Testing

- `appointment-edit.component.spec.ts` (new, 6 cases): URL params override the saved appointment, absent params leave saved values alone, a saved duration isn't clobbered by the URL service's own duration, and the new-appointment seeding path (including its service-duration fallback) still holds.
- `appointments.cy.ts` (new E2E): walks the exact repro — edit an appointment, change date/time/duration/notes, add a client from the lookup, follow the toast to that client's page, press Back, then assert every edit is still there.
- Full frontend unit suite: 245/245. Full E2E suite: 54/54.

`date-time-chooser.component.ts` gains a type-only `dayjs/plugin/isBetween` import so it type-checks under `ng test`, where `app.module` (which registers the plugin at runtime) isn't in the graph — the same pattern already documented in `utils/time-utils.ts`. The client lookup's search box and New button gain `data-test` attributes so the E2E helper can create a client the way a user does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
